### PR TITLE
Added support for path queries and function to join kmers (#61)

### DIFF
--- a/prairiedog/edge.py
+++ b/prairiedog/edge.py
@@ -2,6 +2,7 @@ class Edge:
     """
     Defines a set structure for creating edges
     """
+
     def __init__(self, src: str, tgt: str, edge_type: str = 'e',
                  edge_value: str = 'und', incr: int = None,
                  labels: dict = None, db_id=None):
@@ -16,6 +17,8 @@ class Edge:
             labels.pop('incr')
         else:
             self.incr = incr
+        if self.incr is not None and not isinstance(self.incr, int):
+            self.incr = int(self.incr)
         self.labels = labels
         self.db_id = db_id
 
@@ -24,4 +27,14 @@ class Edge:
         return "{}_{}".format(self.edge_type, self.edge_value)
 
     def __str__(self):
-        return "{}".format(vars(self))
+        return "prairiedog.edge.Edge with vars {}".format(vars(self))
+    #
+    # def __eq__(self, other):
+    #     if not isinstance(other, Edge):
+    #         return False
+    #     else:
+    #         # We don't just test db_id because it might not be present unless
+    #         # queried from the database
+    #         return self.edge_type == other.edge_type \
+    #                and self.edge_value == other.edge_value \
+    #                and self.incr == other.incr

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -16,8 +16,9 @@ class GraphException(Error):
     Generic error for some problem with LemonGraph
     """
     def __init__(self, g: Graph):
-        super(GraphException, self).__init__("Problem with Graph with nodes {}\
-        and edges {}".format(g.nodes, g.edges))
+        super(GraphException, self).__init__(
+            "Problem with Graph with nodes {} and edges {}".format(
+                g.nodes, g.edges))
         log.error("Dumping nodes:")
         for node in g.nodes:
             log.error(node)

--- a/prairiedog/graph.py
+++ b/prairiedog/graph.py
@@ -70,7 +70,7 @@ class Graph(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def connected(self, node_a: str, node_b: str) -> typing.Tuple[
-                    bool, typing.Tuple]:
+            bool, typing.Tuple]:
         pass
 
     @abc.abstractmethod
@@ -92,11 +92,11 @@ class Graph(metaclass=abc.ABCMeta):
     @staticmethod
     def matching_edges(src_edges: typing.Tuple[Edge],
                        tgt_edges: typing.Tuple[Edge]) -> typing.Tuple[
-                        bool, typing.Tuple[Edge]]:
+            bool, typing.Tuple[Edge]]:
         src_map = Graph._edge_map(src_edges)
         tgt_map = Graph._edge_map(tgt_edges)
 
-        list_edges = []
+        list_src_edges = []
         for k, v in src_map.items():
             # Check if there's a target edge with the same origin.
             # We accept the case where the value is the same in case its a
@@ -106,13 +106,13 @@ class Graph(metaclass=abc.ABCMeta):
                 for edge in src_edges:
                     # If this edge is the one we're looking for, add it to ret.
                     if edge.origin == k and edge.incr == v:
-                        list_edges.append(edge)
+                        list_src_edges.append(edge)
 
-        connected = True if len(list_edges) > 0 else False
+        connected = True if len(list_src_edges) > 0 else False
 
         if not connected:
-            log.warning("No connected edges found for src_map {} and tgt_map\
-             {}".format(src_map, tgt_map))
+            log.warning("No connected edges found for src_map {} and tgt_map"
+                        "{}".format(src_map, tgt_map))
         else:
-            log.info("Found connecting edge(s) {} ".format(list_edges))
-        return connected, tuple(list_edges)
+            log.info("Found connecting edge(s) {} ".format(list_src_edges))
+        return connected, tuple(list_src_edges)

--- a/prairiedog/node.py
+++ b/prairiedog/node.py
@@ -1,7 +1,11 @@
+import typing
+
+
 class Node:
     """
     Defines a set structure for creating nodes
     """
+
     def __init__(self, value: str, node_type: str = 'n', db_id: int = None,
                  labels: dict = None):
         self.value = value
@@ -10,4 +14,22 @@ class Node:
         self.labels = labels
 
     def __str__(self):
-        return "{}".format(vars(self))
+        return "prairiedog.node.Node with vars {}".format(vars(self))
+
+
+def concat_values(nodes: typing.Tuple[Node], additional: int = 1) -> str:
+    """
+    Concatenate value strings in Nodes. Used to reconstruct Kmers.
+    :param additional:
+    :param nodes:
+    :return:
+    """
+    if len(nodes) == 0:
+        return ""
+    s = nodes[0].value
+    for i in range(1, len(nodes)):
+        node = nodes[i]
+        # For example: "ABC", "BCD" has additional = 1, so we take "ABC" += "D"
+        suffix = node.value[len(node.value)-additional:]
+        s += suffix
+    return s


### PR DESCRIPTION
* Add the initial code for querying path

* Debug providing Edge.__eq__ broke hashable?

* Add a test against LGGraph.path() that will fail

* Add a test against LGGraph.path() that will fail

* Ignore node in LGGraph.path() query, and unravel

* Convert to a Edge before calling LGGraph._find_path()

* Do a cast to int if Edge.incr is not int

* Fix Edge.incr cast if None, and pass txn into LGGraph._find_path()

* See what chain were getting

* Return the Nodes for a path as a tuple

* Allow tests to pass if working

* <2 not <=2

* <2 not <=2

* Fix: paths is a nested tuple

* Fix linting errors

* Add additional tests for LGGraph.path()

* Add additional tests for LGGraph.path()

* Add code to rejoin Node values, and tests against it

* Add code to rejoin Node values, and tests against it