### PR TITLE
Fixes #70 through setting LemonGraph mapsize (#71)

### DIFF
--- a/prairiedog/edge.py
+++ b/prairiedog/edge.py
@@ -21,18 +21,8 @@ class Edge:
         self.db_id = db_id
 
     @property
-    def origin(self):
-        return "{}".format(self.edge_type)
+    def origin(self) -> str:
+        return self.edge_type
 
     def __str__(self):
         return "prairiedog.edge.Edge with vars {}".format(vars(self))
-    #
-    # def __eq__(self, other):
-    #     if not isinstance(other, Edge):
-    #         return False
-    #     else:
-    #         # We don't just test db_id because it might not be present unless
-    #         # queried from the database
-    #         return self.edge_type == other.edge_type \
-    #                and self.edge_value == other.edge_value \
-    #                and self.incr == other.incr

--- a/prairiedog/lemon_graph.py
+++ b/prairiedog/lemon_graph.py
@@ -32,6 +32,8 @@ class LGGraph(prairiedog.graph.Graph):
         log.debug("Creating LemonGraph with backing file {}".format(
             self.db_path))
         self.g = LemonGraph.Graph(self.db_path)
+        ret = LemonGraph.lib.graph_set_mapsize(self.g._graph, (4 << 30) * 10)
+        assert (0 == ret)
         self._ctx = None
         self._txn = None
         self.delete_on_exit = delete_on_exit


### PR DESCRIPTION
* Hopefully its just the length of the edge keys

* Fix some overlap between edge_type and origin

* Fix dbm str cast

* Use a regular dict for testing for now

* Set a map size identical the lemongraphs own bench.py

* Fix g call

* Setting the map size seemed to fix it, now try without encoding the kmer headers

* Delete dbm_map.py

* Bump the mapsize up considerably

* Write a simpler Graph.matching_edges()