### PR TITLE
Support for `nosync` option, and increase map size (#89)

### DIFF
--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -2,15 +2,21 @@
 
 """Console script for prairiedog."""
 import click
+import os
 
 from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
-from prairiedog.lemon_graph import LGGraph
+from prairiedog.lemon_graph import LGGraph, DB_PATH
 
 # If cli is imported, re-setup logging to level INFO
 setup_logging("INFO")
 
-pdg = Prairiedog(g=LGGraph())
+# If the path doesn't exist (ie. a tempfile for tests), LemonGraph will
+# error out if you set readonly
+if os.path.exists(DB_PATH):
+    pdg = Prairiedog(g=LGGraph(readonly=True))
+else:
+    pdg = Prairiedog(g=LGGraph(readonly=False))
 
 
 @click.command()

--- a/prairiedog/lemon_graph.py
+++ b/prairiedog/lemon_graph.py
@@ -24,7 +24,8 @@ class LGGraph(prairiedog.graph.Graph):
     LemonGraph defines directed edges.
     """
 
-    def __init__(self, db_path: str = None, delete_on_exit=False):
+    def __init__(self, db_path: str = None, delete_on_exit=False, nosync=True,
+                 noreadahead=True, readonly=False):
         if db_path is not None:
             self.db_path = db_path
         else:
@@ -32,8 +33,9 @@ class LGGraph(prairiedog.graph.Graph):
             self.db_path = DB_PATH
         log.debug("Creating LemonGraph with backing file {}".format(
             self.db_path))
-        self.g = LemonGraph.Graph(self.db_path)
-        ret = LemonGraph.lib.graph_set_mapsize(self.g._graph, (4 << 30) * 10)
+        self.g = LemonGraph.Graph(path=self.db_path, nosync=nosync,
+                                  noreadahead=noreadahead, readonly=readonly)
+        ret = LemonGraph.lib.graph_set_mapsize(self.g._graph, (20 << 30) * 10)
         assert (0 == ret)
         self._ctx = None
         self._txn = None
@@ -44,7 +46,7 @@ class LGGraph(prairiedog.graph.Graph):
         Deletes the database file on garbage collection
         :return:
         """
-        if self.delete_on_exit:
+        if self.delete_on_exit is True:
             log.debug("Wiping LemonGraph with backing file {}".format(
                 self.db_path))
             self.clear()


### PR DESCRIPTION
* Set readyonly and noreadyahead = True by default, and set readonly=True on cli queries

* Check that the db file exists before setting readonly

* Check that the db file exists before setting readonly

* Bump mapsize