### PR TITLE
Support Dgraph Bulk Load

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,15 +51,10 @@ jobs:
                   paths:
                       - "venv"
 
-#            - run:
-#                  name: install dgraph
-#                  command: |
-#                      curl https://get.dgraph.io -sSf | bash
-
             - run:
                   name: install dgraph
                   command: |
-                      cp -rf gobin/go/bin/* /usr/local/bin/
+                      curl https://get.dgraph.io -sSf | bash
 
             - run:
                   name: update pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,16 @@ jobs:
                   name: install lemongraph
                   command: |
                       . venv/bin/activate
-                      apt-get update -y && apt-get install -y libffi-dev zlib1g-dev python-dev python-cffi libatlas-base-dev
                       pip install --upgrade cffi
                       cd lemongraph && python setup.py install
+
+#            - run:
+#                  name: install lemongraph
+#                  command: |
+#                      . venv/bin/activate
+#                      apt-get update -y && apt-get install -y libffi-dev zlib1g-dev python-dev python-cffi libatlas-base-dev
+#                      pip install --upgrade cffi
+#                      cd lemongraph && python setup.py install
 
             - run:
                   name: install dgraph

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
                       git submodule init
                       git submodule update --remote
 
+            - restore_cache:
+                  key: deps1-{{ .Branch }}-{{ checksum "requirements_dev.txt" }}
+
             - run:
                   name: install dependencies
                   command: |
@@ -35,13 +38,18 @@ jobs:
                       pip install --upgrade cffi
                       cd lemongraph && python setup.py install
 
-#            - run:
-#                  name: install lemongraph
-#                  command: |
-#                      . venv/bin/activate
-#                      apt-get update -y && apt-get install -y libffi-dev zlib1g-dev python-dev python-cffi libatlas-base-dev
-#                      pip install --upgrade cffi
-#                      cd lemongraph && python setup.py install
+            #            - run:
+            #                  name: install lemongraph
+            #                  command: |
+            #                      . venv/bin/activate
+            #                      apt-get update -y && apt-get install -y libffi-dev zlib1g-dev python-dev python-cffi libatlas-base-dev
+            #                      pip install --upgrade cffi
+            #                      cd lemongraph && python setup.py install
+
+            - save_cache:
+                  key: deps1-{{ .Branch }}-{{ checksum "requirements_dev.txt" }}
+                  paths:
+                      - "venv"
 
             - run:
                   name: install dgraph

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,15 @@ jobs:
                   paths:
                       - "venv"
 
+#            - run:
+#                  name: install dgraph
+#                  command: |
+#                      curl https://get.dgraph.io -sSf | bash
+
             - run:
                   name: install dgraph
                   command: |
-                      curl https://get.dgraph.io -sSf | bash
+                      cp -rf gobin/go/bin/* /usr/local/bin/
 
             - run:
                   name: update pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN cd lemongraph/ && python setup.py install
 # setup.py
 RUN python setup.py install
 
-ENTRYPOINT ["snakemake", "-j"]
+ENTRYPOINT ["prairiedog"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM superphy/tox-base:d698931a52ddeef64dcf5918b32790bcef75af61
+FROM superphy/tox-base:af2794de54ad6edf097552d06d69be541f3bd419
 
 MAINTAINER Kevin Le <kevin.kent.le@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ RUN git submodule init && git submodule update --remote
 # Setup PyPy3 virtualenv
 ENV VIRTUAL_ENV=/opt/venv
 RUN pypy3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:/p/gobin/go/bin:$PATH"
+#ENV PATH="$VIRTUAL_ENV/bin:/p/gobin/go/bin:$PATH"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install dgraph
+RUN curl https://get.dgraph.io -sSf | bash
 
 # Install deps
 RUN pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,17 @@ For creating a graph
 For querying an existing graph
 -------------------------------
 
+Via docker
+
+::
+
+    # Without debug
+    docker run -v /home/kevin/pdg-test/outputs:/p/outputs/ -v /home/kevin/pdg-test/samples:/p/samples/ superphy/prairiedog:c6ff5c63779a73de02c9b3de0f4225b29564f285 query TCGAGCATTAT GCATAGGCAAC
+    # With debug
+    docker run -v /home/kevin/pdg-test/outputs:/p/outputs/ -v /home/kevin/pdg-test/samples:/p/samples/ superphy/prairiedog:c6ff5c63779a73de02c9b3de0f4225b29564f285 --debug query TCGAGCATTAT GCATAGGCAAC
+
+or virtualenv
+
 ::
 
     . venv/bin/activate

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ prairiedog
 .. image:: https://codecov.io/gh/superphy/prairiedog/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/superphy/prairiedog
 
-Supports Python3.5+ on Linux
+Supports Python3.6, Python3.7, PyPy3.6 on Linux
 
 ============
 Installation

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ prairiedog
 .. image:: https://codecov.io/gh/superphy/prairiedog/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/superphy/prairiedog
 
-Supports Python3.6, Python3.7, PyPy3.6 on Linux
+Supports Python 3.6, Python 3.7, PyPy 3.6 on Linux
 
 ============
 Installation

--- a/Snakefile
+++ b/Snakefile
@@ -153,7 +153,7 @@ rule dgraph:
         print("Done initializing built-in dgraph instance.")
         # Execute dgraph bulk
         p = port('ZERO', offset)
-        run_dgraph_bulk(cwd=outputs_dir, move_to=dgraph_output, rdfs=rdfs,
+        run_dgraph_bulk(cwd=outputs_dir, move_to=dg.postings_dir, rdfs=rdfs,
                         zero_port=p)
         # Create the done file
         open(output[0], 'w').close()

--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,7 @@ configfile: "config.yaml"
 
 K = config["k"]
 
-INPUTS = [os.path.splitext(f)[0] for f in os.listdir(config["samples"])
+INPUTS = [os.path.splitext(f)[0] for f in os.listdir(config["samples_dir"])
            if f.endswith(('.fna', '.fasta', '.fa'))
 ]
 

--- a/Snakefile
+++ b/Snakefile
@@ -120,6 +120,7 @@ rule preload:
         print("Done creating rdf for all possible k-mers.")
         print("Trying to save rdf to file {}".format(output[0]))
         dg.save(output[0])
+        print("Saved rdf as {}".format(output[0]))
 
 rule dgraph:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -44,19 +44,9 @@ rule kmers:
         km = Kmers(input[0],K)
         dill.dump(km, open(output[0],'wb'))
 
-rule preload:
-    output:
-        'outputs/preloaded.txt'
-    run:
-        # if config['backend'] == 'dgraph':
-        #     dg = Dgraph()
-        #     dg.preload(K)
-        open(output[0], 'w').close()
-
 rule pangenome:
     input:
-        'outputs/kmers/{input}.pkl',
-        'outputs/preloaded.txt'
+        'outputs/kmers/{input}.pkl'
     output:
         'outputs/pangenome_{input}.g'
     run:
@@ -116,9 +106,22 @@ rule done:
     run:
         open(output[0], 'w').close()
 
+###########
+# Dgraph specific rules
+###########
+
+rule preload:
+    output:
+        'outputs/samples/kmers.rdf'
+    run:
+        dg = DgraphBulk()
+        dg.preload(K)
+        dg.save(output[0])
+
 rule dgraph:
     input:
-        'outputs/pangenome.g'
+        'outputs/pangenome.g',
+        'outputs/samples/kmers.rdf'
     output:
         'outputs/dgraph.done'
     run:

--- a/Snakefile
+++ b/Snakefile
@@ -28,8 +28,8 @@ if os.path.isfile(MIC_CSV):
     MIC_COLUMNS = set(pd.read_csv(MIC_CSV).columns)
     MIC_COLUMNS.remove('run')
 
-samples_dir = config['samples']
-outputs_dir = config['outputs']
+samples_dir = config['samples_dir']
+outputs_dir = config['outputs_dir']
 
 print("Snakemake will run with samples dir {} and output dir {}".format(
     samples_dir, outputs_dir

--- a/Snakefile
+++ b/Snakefile
@@ -144,13 +144,16 @@ rule dgraph:
         os.path.join(outputs_dir, 'dgraph.done')
     run:
         dgraph_output = os.path.join(outputs_dir, 'dgraph/')
-        rdfs = os.path.join(dgraph_output, 'samples/')
+        rdfs = os.path.join(outputs_dir, 'samples/')
         # Create a reference to a running Dgraph instance
+        print("Initializing built-in dgraph instance...")
         dg = DgraphBundled(
             delete=False,
             output_folder=dgraph_output)
+        print("Done initializing built-in dgraph instance.")
         # Execute dgraph bulk
         p = port('ZERO', offset)
+        print("Executing dgraph bulk command")
         shell(dgraph_bulk_cmd(rdfs=rdfs, zero_port=p))
         # Create the done file
         open(output[0], 'w').close()

--- a/Snakefile
+++ b/Snakefile
@@ -31,6 +31,10 @@ if os.path.isfile(MIC_CSV):
 samples_dir = config['samples']
 outputs_dir = config['outputs']
 
+print("Snakemake will run with samples dir {} and output dir {}".format(
+    samples_dir, outputs_dir
+))
+
 ###################
 # Graphing steps
 ###################

--- a/Snakefile
+++ b/Snakefile
@@ -13,7 +13,7 @@ from prairiedog.subgraph_ref import SubgraphRef
 from prairiedog.lemon_graph import LGGraph, DB_PATH
 from prairiedog.dgraph import DgraphBulk, port
 from prairiedog.dgraph_bundled import DgraphBundled, offset
-from dgraph.bulk import dgraph_bulk_cmd
+from dgraph.bulk import run_dgraph_bulk
 
 configfile: "config.yaml"
 
@@ -153,8 +153,8 @@ rule dgraph:
         print("Done initializing built-in dgraph instance.")
         # Execute dgraph bulk
         p = port('ZERO', offset)
-        print("Executing dgraph bulk command")
-        shell(dgraph_bulk_cmd(rdfs=rdfs, zero_port=p))
+        run_dgraph_bulk(cwd=outputs_dir, move_to=dgraph_output, rdfs=rdfs,
+                        zero_port=p)
         # Create the done file
         open(output[0], 'w').close()
 

--- a/Snakefile
+++ b/Snakefile
@@ -115,7 +115,10 @@ rule preload:
         'outputs/samples/kmers.rdf'
     run:
         dg = DgraphBulk()
+        print("Trying to create rdf for all possible k-mers...")
         dg.preload(K)
+        print("Done creating rdf for all possible k-mers.")
+        print("Trying to save rdf to file {}".format(output[0]))
         dg.save(output[0])
 
 rule dgraph:

--- a/Snakefile
+++ b/Snakefile
@@ -143,8 +143,8 @@ rule dgraph:
     output:
         os.path.join(outputs_dir, 'dgraph.done')
     run:
-        dgraph_output = os.path.join(outputs_dir, 'dgraph/')
-        rdfs = os.path.join(outputs_dir, 'samples/')
+        dgraph_output = pathlib.Path(outputs_dir, 'dgraph/').resolve()
+        rdfs = pathlib.Path(outputs_dir, 'samples/').resolve()
         # Create a reference to a running Dgraph instance
         print("Initializing built-in dgraph instance...")
         dg = DgraphBundled(

--- a/Snakefile
+++ b/Snakefile
@@ -12,7 +12,7 @@ from prairiedog.graph_ref import GraphRef
 from prairiedog.subgraph_ref import SubgraphRef
 from prairiedog.lemon_graph import LGGraph, DB_PATH
 from prairiedog.dgraph import DgraphBulk, port
-from prairiedog.dgraph_bundled import DgraphBundled, offset
+from prairiedog.dgraph_bundled_helper import DgraphBundledHelper
 from dgraph.bulk import run_dgraph_bulk
 
 configfile: "config.yaml"
@@ -146,15 +146,10 @@ rule dgraph:
         dgraph_output = pathlib.Path(outputs_dir, 'dgraph/').resolve()
         rdfs = pathlib.Path(outputs_dir, 'samples/').resolve()
         # Create a reference to a running Dgraph instance
-        print("Initializing built-in dgraph instance...")
-        dg = DgraphBundled(
-            delete=False,
-            output_folder=dgraph_output)
-        print("Done initializing built-in dgraph instance.")
+        # DgraphBundledHelper will resolve output directory to ./dgraph/
+        dgh = DgraphBundledHelper(out_dir=outputs_dir)
         # Execute dgraph bulk
-        p = port('ZERO', offset)
-        run_dgraph_bulk(cwd=outputs_dir, move_to=dg.postings_dir, rdfs=rdfs,
-                        zero_port=p)
+        dgh.load(rdf_dir=rdfs, delete_after=False)
         # Create the done file
         open(output[0], 'w').close()
 

--- a/Snakefile
+++ b/Snakefile
@@ -143,13 +143,15 @@ rule dgraph:
     output:
         os.path.join(outputs_dir, 'dgraph.done')
     run:
+        dgraph_output = os.path.join(outputs_dir, 'dgraph/')
+        rdfs = os.path.join(dgraph_output, 'samples/')
         # Create a reference to a running Dgraph instance
         dg = DgraphBundled(
             delete=False,
-            output_folder=os.path.join(outputs_dir, 'dgraph/'))
+            output_folder=dgraph_output)
         # Execute dgraph bulk
         p = port('ZERO', offset)
-        shell(dgraph_bulk_cmd(zero_port=p))
+        shell(dgraph_bulk_cmd(rdfs=rdfs, zero_port=p))
         # Create the done file
         open(output[0], 'w').close()
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
-samples:
+samples_dir:
     samples/
 
-outputs:
+outputs_dir:
     outputs/
 
 k:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,12 @@
 samples:
     samples/
+
+outputs:
+    outputs/
+
 k:
     11
+
 graph_labels:
     samples/public_mic_class_dataframe.csv
 

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -2,6 +2,7 @@ import subprocess
 import logging
 import glob
 import shutil
+import pathlib
 
 from prairiedog import recommended_procs
 
@@ -34,10 +35,12 @@ def run_dgraph_bulk(cwd: str = '.', move_to: str = None, **kwargs):
     log.info("Executing {} from {}".format(cmd, cwd))
     subprocess.run(cmd, shell=True, cwd=cwd)
     log.info("Done running dgraph bulk")
-    files = glob.glob("{}/**".format(cwd), recursive=True)
-
-    # TODO: remove this
-    log.critical("CWD files are {}".format(files))
+    p = pathlib.Path(cwd, 'out', '0', 'p')
+    if not p.exists():
+        raise Exception("Path {} was not found".format(p))
+    else:
+        files = glob.glob("{}/**".format(p), recursive=True)
+        log.info("Output in {} is {}".format(p, files))
 
     if move_to is not None:
         log.info("Will move files to {}".format(move_to))

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -3,6 +3,7 @@ import logging
 import glob
 import shutil
 import pathlib
+import os
 
 from prairiedog import recommended_procs
 
@@ -33,7 +34,7 @@ def dgraph_bulk_cmd(
 
 def run_dgraph_bulk(cwd: str = '.', move_to: str = None, **kwargs):
     cmd = dgraph_bulk_cmd(**kwargs)
-    log.info("Executing {} from {}".format(cmd, cwd))
+    log.info("Executing:\n{}\nfrom {}".format(cmd, cwd))
     subprocess.run(cmd, shell=True, cwd=cwd)
     log.info("Done running dgraph bulk")
     p = pathlib.Path(cwd, 'out', '0', 'p')
@@ -41,8 +42,11 @@ def run_dgraph_bulk(cwd: str = '.', move_to: str = None, **kwargs):
         raise Exception("Path {} was not found".format(p))
     else:
         files = glob.glob("{}/**".format(p), recursive=True)
-        log.info("Output in {} is {}".format(p, files))
+        log.info("Output in {} is:\n{}".format(p, files))
 
     if move_to is not None:
-        log.info("Will move files to {}".format(move_to))
-        shutil.copytree(cwd, move_to)
+        log.info("Will move files from {} to {}".format(p, move_to))
+        if os.path.isdir(move_to):
+            log.warning("Will delete {} as it already exists".format(move_to))
+            shutil.rmtree(move_to)
+        shutil.move(p, move_to)

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -10,7 +10,7 @@ def dgraph_bulk_cmd(
     rdfs: str = 'outputs/samples/', schema: str = 'dgraph/kmers.schema',
         zero_port: int = 5080) -> str:
     run_cmd = "dgraph bulk \
-    -f {rdfs} \
+    -r {rdfs} \
     -s {schema} \
     -j {n_procs} \
     --map_shards=1 \

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -47,6 +47,6 @@ def run_dgraph_bulk(cwd: str = '.', move_to: str = None, **kwargs):
     if move_to is not None:
         log.info("Will move files from {} to {}".format(p, move_to))
         if os.path.isdir(move_to):
-            log.warning("Will delete {} as it already exists".format(move_to))
+            log.warning("Deleting {} as it already exists".format(move_to))
             shutil.rmtree(move_to)
         shutil.move(p, move_to)

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -15,7 +15,8 @@ recommended_procs_dgraph = recommended_procs(GB_PER_PROC_DGRAPH)
 
 
 def dgraph_bulk_cmd(
-    rdfs: str = 'outputs/samples/', schema: str = 'dgraph/kmers.schema',
+        rdfs: pathlib.Path = pathlib.Path('outputs/samples/').resolve(),
+        schema: pathlib.Path = pathlib.Path('dgraph/kmers.schema').resolve(),
         zero_port: int = 5080) -> str:
     run_cmd = "dgraph bulk \
     -r {rdfs} \

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -1,20 +1,9 @@
-import psutil
+from prairiedog import recommended_procs
 
 # Calculations for Dgraph Bulk processes, this was based off our tests
-GB_PER_PROC = 94 / 12
+GB_PER_PROC_DGRAPH = 94 / 12
 
-
-def recommended_procs() -> int:
-    vm_bytes = psutil.virtual_memory().total
-    vm_gb = vm_bytes / (1 << 30)
-    procs_by_mem = int(vm_gb / GB_PER_PROC)
-    cpus = psutil.cpu_count()
-    if procs_by_mem < cpus:
-        # Memory is the limitation
-        return procs_by_mem
-    else:
-        # Plenty of memory, use all CPUs
-        return cpus
+recommended_procs_dgraph = recommended_procs(GB_PER_PROC_DGRAPH)
 
 
 def dgraph_bulk_cmd(
@@ -28,7 +17,7 @@ def dgraph_bulk_cmd(
     --reduce_shards=1 \
     --http localhost:8001 \
     --zero=localhost:{zero_port}".format(
-        rdfs=rdfs, schema=schema, n_procs=recommended_procs(),
+        rdfs=rdfs, schema=schema, n_procs=recommended_procs_dgraph,
         zero_port=zero_port)
     return run_cmd
 

--- a/dgraph/bulk.py
+++ b/dgraph/bulk.py
@@ -1,4 +1,11 @@
+import subprocess
+import logging
+import glob
+import shutil
+
 from prairiedog import recommended_procs
+
+log = logging.getLogger('prairiedog')
 
 # Calculations for Dgraph Bulk processes, this was based off our tests
 GB_PER_PROC_DGRAPH = 94 / 12
@@ -21,3 +28,17 @@ def dgraph_bulk_cmd(
         zero_port=zero_port)
     return run_cmd
 
+
+def run_dgraph_bulk(cwd: str = '.', move_to: str = None, **kwargs):
+    cmd = dgraph_bulk_cmd(**kwargs)
+    log.info("Executing {} from {}".format(cmd, cwd))
+    subprocess.run(cmd, shell=True, cwd=cwd)
+    log.info("Done running dgraph bulk")
+    files = glob.glob("{}/**".format(cwd), recursive=True)
+
+    # TODO: remove this
+    log.critical("CWD files are {}".format(files))
+
+    if move_to is not None:
+        log.info("Will move files to {}".format(move_to))
+        shutil.copytree(cwd, move_to)

--- a/prairiedog/__init__.py
+++ b/prairiedog/__init__.py
@@ -6,7 +6,22 @@ __author__ = """Kevin Le"""
 __email__ = 'kevin.kent.le@gmail.com'
 __version__ = '0.1.1'
 
+import psutil
+
 from prairiedog.logger import setup_logging
 
 # Initialize logging
 setup_logging()
+
+
+def recommended_procs(gb_per_proc) -> int:
+    vm_bytes = psutil.virtual_memory().total
+    vm_gb = vm_bytes / (1 << 30)
+    procs_by_mem = int(vm_gb / gb_per_proc)
+    cpus = psutil.cpu_count()
+    if procs_by_mem < cpus:
+        # Memory is the limitation
+        return procs_by_mem
+    else:
+        # Plenty of memory, use all CPUs
+        return cpus

--- a/prairiedog/__init__.py
+++ b/prairiedog/__init__.py
@@ -6,6 +6,9 @@ __author__ = """Kevin Le"""
 __email__ = 'kevin.kent.le@gmail.com'
 __version__ = '0.1.1'
 
+import logging
+import os
+
 import psutil
 
 from prairiedog.logger import setup_logging
@@ -25,3 +28,14 @@ def recommended_procs(gb_per_proc) -> int:
     else:
         # Plenty of memory, use all CPUs
         return cpus
+
+
+def debug_and_not_ci() -> bool:
+    """Defined as a function so we can eval on call"""
+    log = logging.getLogger('prairiedog')
+    debug = log.isEnabledFor(logging.DEBUG)
+    ci = os.getenv('CI') == 'true'
+    if debug and not ci:
+        return True
+    else:
+        return False

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -26,13 +26,24 @@ def connect_lemongraph() -> LGGraph:
     return g
 
 
+def connect_dgraph() -> DgraphBundled:
+    p = 'outputs/dgraph/'
+    # If the path exists, this was called after a Snakemake run.
+    # Otherwise, "query" was called without computing the backend graph.
+    if os.path.isdir(p):
+        g = DgraphBundled(delete=False, output_folder=p)
+    else:
+        g = DgraphBundled()
+    return g
+
+
 def parse_backend(backend: str) -> Graph:
     if backend == 'dgraph':
-        g = DgraphBundled()
+        g = connect_dgraph()
     elif backend == 'lemongraph':
         g = connect_lemongraph()
     else:
-        g = DgraphBundled(delete=False, output_folder='outputs/dgraph/')
+        g = connect_dgraph()
     return g
 
 

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -50,7 +50,7 @@ def parse_backend(backend: str) -> Graph:
     return g
 
 
-def run_dgraph_snakemake(additional_str: str):
+def run_dgraph_snakemake(additional_str: str = ""):
     """Helper to execute snakemake for dgraph"""
     cmd = "snakemake --config backend=dgraph {c} -j {j}  dgraph".format(
         c=additional_str, j=recommended_procs_kmers)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -31,7 +31,7 @@ def parse_backend(backend: str) -> Graph:
     elif backend == 'lemongraph':
         g = connect_lemongraph()
     else:
-        g = DgraphBundled()
+        g = DgraphBundled(delete=False, output_folder='outputs/dgraph/')
     return g
 
 

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -5,8 +5,6 @@ import click
 import os
 import subprocess
 
-import psutil
-
 from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
 from prairiedog.graph import Graph

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -5,6 +5,7 @@ import click
 import os
 import subprocess
 import logging
+import signal
 
 from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
@@ -29,14 +30,14 @@ def connect_lemongraph() -> LGGraph:
     return g
 
 
-def connect_dgraph() -> DgraphBundled:
+def connect_dgraph(**kwargs) -> DgraphBundled:
     p = 'outputs/dgraph/'
     # If the path exists, this was called after a Snakemake run.
     # Otherwise, "query" was called without computing the backend graph.
     if os.path.isdir(p):
-        g = DgraphBundled(delete=False, output_folder=p)
+        g = DgraphBundled(delete=False, output_folder=p, **kwargs)
     else:
-        g = DgraphBundled()
+        g = DgraphBundled(**kwargs)
     return g
 
 
@@ -81,3 +82,11 @@ def query(src: str, dst: str, backend: str):
 def dgraph():
     """Create a pan-genome."""
     run_dgraph_snakemake()
+
+
+@cli.command()
+def ratel():
+    g = connect_dgraph(ratel=True)
+    log.info("Initialzied {}".format(g))
+    # Suspend the main thread
+    signal.pause()

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -47,6 +47,12 @@ def parse_backend(backend: str) -> Graph:
     return g
 
 
+def run_dgraph_snakemake(additional_str: str):
+    """Helper to execute snakemake for dgraph"""
+    subprocess.run("snakemake --config backend=dgraph -j {} {} dgraph".format(
+        recommended_procs_kmers, additional_str), shell=True)
+
+
 @click.group()
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
@@ -69,5 +75,4 @@ def query(src: str, dst: str, backend: str):
 @cli.command()
 def dgraph():
     """Create a pan-genome."""
-    subprocess.run("snakemake --config backend=dgraph -j {} dgraph".format(
-        recommended_procs_kmers), shell=True)
+    run_dgraph_snakemake()

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -9,7 +9,7 @@ from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
 from prairiedog.graph import Graph
 from prairiedog.lemon_graph import LGGraph, DB_PATH
-from prairiedog.dgraph import Dgraph
+from prairiedog.dgraph_bundled import DgraphBundled
 
 # If cli is imported, re-setup logging to level INFO
 setup_logging("INFO")
@@ -27,11 +27,11 @@ def connect_lemongraph() -> LGGraph:
 
 def parse_backend(backend: str) -> Graph:
     if backend == 'dgraph':
-        g = Dgraph()
+        g = DgraphBundled()
     elif backend == 'lemongraph':
         g = connect_lemongraph()
     else:
-        g = Dgraph()
+        g = DgraphBundled()
     return g
 
 

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -44,9 +44,9 @@ def cli(debug):
 
 
 @cli.command()
-@cli.argument('src', nargs=1)
-@cli.argument('dst', nargs=1)
-@cli.option('--backend', default='dgraph', help='Backend graph database')
+@click.argument('src', nargs=1)
+@click.argument('dst', nargs=1)
+@click.option('--backend', default='dgraph', help='Backend graph database')
 def query(src: str, dst: str, backend: str):
     """Query the pan-genome for a path between two k-mers."""
     g = parse_backend(backend)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -35,10 +35,18 @@ def parse_backend(backend: str) -> Graph:
     return g
 
 
-@click.command()
-@click.argument('src', nargs=1)
-@click.argument('dst', nargs=1)
-@click.option('--backend', default='dgraph', help='Backend graph database')
+@click.group()
+@click.option('--debug/--no-debug', default=False)
+def cli(debug):
+    click.echo('Debug mode is %s' % ('on' if debug else 'off'))
+    if debug:
+        setup_logging('DEBUG')
+
+
+@cli.command()
+@cli.argument('src', nargs=1)
+@cli.argument('dst', nargs=1)
+@cli.option('--backend', default='dgraph', help='Backend graph database')
 def query(src: str, dst: str, backend: str):
     """Query the pan-genome for a path between two k-mers."""
     g = parse_backend(backend)
@@ -46,7 +54,7 @@ def query(src: str, dst: str, backend: str):
     pdg.query(src, dst)
 
 
-@click.command()
+@cli.command()
 def dgraph():
     """Create a pan-genome."""
     subprocess.run("snakemake -j dgraph", shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -69,5 +69,5 @@ def query(src: str, dst: str, backend: str):
 @cli.command()
 def dgraph():
     """Create a pan-genome."""
-    subprocess.run("snakemake -j {} dgraph".format(
+    subprocess.run("snakemake --config backend=dgraph -j {} dgraph".format(
         recommended_procs_kmers), shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -87,5 +87,6 @@ def dgraph():
 @cli.command()
 def ratel():
     g = connect_dgraph(ratel=True)
+    log.debug("Initialized {}".format(g))
     # Suspend the main thread
     signal.pause()

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -43,7 +43,7 @@ def cli(debug):
         setup_logging('DEBUG')
 
 
-@cli.command('query')
+@cli.command()
 @click.argument('src', nargs=1)
 @click.argument('dst', nargs=1)
 @click.option('--backend', default='dgraph', help='Backend graph database')
@@ -54,7 +54,7 @@ def query(src: str, dst: str, backend: str):
     pdg.query(src, dst)
 
 
-@cli.command('dgraph')
+@cli.command()
 def dgraph():
     """Create a pan-genome."""
     subprocess.run("snakemake -j dgraph", shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -5,6 +5,8 @@ import click
 import os
 import subprocess
 
+import psutil
+
 from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
 from prairiedog.graph import Graph
@@ -57,4 +59,5 @@ def query(src: str, dst: str, backend: str):
 @cli.command()
 def dgraph():
     """Create a pan-genome."""
-    subprocess.run("snakemake -j dgraph", shell=True)
+    subprocess.run("snakemake -j {} dgraph".format(
+        psutil.cpu_count()), shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -4,6 +4,7 @@
 import click
 import os
 import subprocess
+import logging
 
 from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
@@ -14,6 +15,8 @@ from prairiedog.kmers import recommended_procs_kmers
 
 # If cli is imported, re-setup logging to level INFO
 setup_logging("INFO")
+
+log = logging.getLogger('prairiedog')
 
 
 def connect_lemongraph() -> LGGraph:
@@ -49,8 +52,10 @@ def parse_backend(backend: str) -> Graph:
 
 def run_dgraph_snakemake(additional_str: str):
     """Helper to execute snakemake for dgraph"""
-    subprocess.run("snakemake --config backend=dgraph -j {} {} dgraph".format(
-        recommended_procs_kmers, additional_str), shell=True)
+    cmd = "snakemake --config backend=dgraph {c} -j {j}  dgraph".format(
+        c=additional_str, j=recommended_procs_kmers)
+    log.info("Executing Snakemake with cmd:\n{}".format(cmd))
+    subprocess.run(cmd, shell=True)
 
 
 @click.group()

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -43,7 +43,7 @@ def cli(debug):
         setup_logging('DEBUG')
 
 
-@cli.command()
+@cli.command('query')
 @click.argument('src', nargs=1)
 @click.argument('dst', nargs=1)
 @click.option('--backend', default='dgraph', help='Backend graph database')
@@ -54,7 +54,7 @@ def query(src: str, dst: str, backend: str):
     pdg.query(src, dst)
 
 
-@cli.command()
+@cli.command('dgraph')
 def dgraph():
     """Create a pan-genome."""
     subprocess.run("snakemake -j dgraph", shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -12,6 +12,7 @@ from prairiedog.prairiedog import Prairiedog
 from prairiedog.graph import Graph
 from prairiedog.lemon_graph import LGGraph, DB_PATH
 from prairiedog.dgraph_bundled import DgraphBundled
+from prairiedog.kmers import recommended_procs_kmers
 
 # If cli is imported, re-setup logging to level INFO
 setup_logging("INFO")
@@ -60,4 +61,4 @@ def query(src: str, dst: str, backend: str):
 def dgraph():
     """Create a pan-genome."""
     subprocess.run("snakemake -j {} dgraph".format(
-        psutil.cpu_count()), shell=True)
+        recommended_procs_kmers), shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -3,6 +3,7 @@
 """Console script for prairiedog."""
 import click
 import os
+import subprocess
 
 from prairiedog.logger import setup_logging
 from prairiedog.prairiedog import Prairiedog
@@ -39,6 +40,13 @@ def parse_backend(backend: str) -> Graph:
 @click.argument('dst', nargs=1)
 @click.option('--backend', default='dgraph', help='Backend graph database')
 def query(src: str, dst: str, backend: str):
+    """Query the pan-genome for a path between two k-mers."""
     g = parse_backend(backend)
     pdg = Prairiedog(g=g)
     pdg.query(src, dst)
+
+
+@click.command()
+def dgraph():
+    """Create a pan-genome."""
+    subprocess.run("snakemake -j dgraph", shell=True)

--- a/prairiedog/cli.py
+++ b/prairiedog/cli.py
@@ -87,6 +87,5 @@ def dgraph():
 @cli.command()
 def ratel():
     g = connect_dgraph(ratel=True)
-    log.info("Initialzied {}".format(g))
     # Suspend the main thread
     signal.pause()

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -553,8 +553,12 @@ class DgraphBulk(Graph):
         pass
 
     def preload(self, k: int = 11):
-        self.nquads = '\n'.join('_:{kmer} <km> "{kmer}" .'.format(kmer=kmer)
-                                for kmer in possible_kmers(k))
+        self.nquads = '\n'.join(
+            '_:{kmer} <{nt}> "{kmer}" .'.format(
+                kmer=kmer, nt=DEFAULT_NODE_TYPE
+            )
+            for kmer in possible_kmers(k)
+        )
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:
         # The hash is used to ensure blank nodes are unique before assignment

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -28,6 +28,9 @@ def port(component: str, offset: int = 0) -> int:
         return 5080 + offset
     elif component == "ALPHA":
         return 9080 + offset
+    elif component == "RATEL":
+        log.debug("Ratel port isn't controlled with an offset")
+        return 8000
 
 
 def decode(b: bytes):

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -554,7 +554,7 @@ class DgraphBulk(Graph):
 
     def preload(self, k: int = 11):
         self.nquads = '\n'.join('_:{kmer} <km> "{kmer}" .'.format(kmer=kmer)
-                               for kmer in possible_kmers(k))
+                                for kmer in possible_kmers(k))
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:
         # The hash is used to ensure blank nodes are unique before assignment

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -25,10 +25,17 @@ DEFAULT_EDGE_PREDICATE = 'fd'
 
 def port(component: str, offset: int = 0) -> int:
     if component == "ZERO":
+        # gRPC port
         return 5080 + offset
+    elif component == "ZERO_HTTP":
+        return 6080 + offset
     elif component == "ALPHA":
+        # gRPC port
         return 9080 + offset
+    elif component == "ALPHA_HTTP":
+        return 8080 + offset
     elif component == "RATEL":
+        # HTTP port
         log.debug("Ratel port isn't controlled with an offset")
         return 8000
 

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -65,17 +65,6 @@ class Dgraph(Graph):
         if self._client_stub is not None:
             self.client_stub.close()
 
-    def preload(self, k: int = 11):
-        nquads = ""
-        c = 0
-        for kmer in possible_kmers(k):
-            nquads += ' _:{kmer} <km> "{kmer}" .'.format(kmer=kmer)
-            c += 1
-            if c % 333 == 0:
-                self.mutate(nquads)
-                nquads = ""
-        self.mutate(nquads)
-
     def query(self, q: str):
         log.debug("Using query: \n{}".format(q))
         res = self.client.txn(read_only=True).query(q)
@@ -562,6 +551,12 @@ class DgraphBulk(Graph):
     def upsert_node(self, node: Node, echo: bool = True) -> typing.Optional[
             Node]:
         pass
+
+    def preload(self, k: int = 11):
+        for kmer in possible_kmers(k):
+            self.nquads += """
+            _:{kmer} <km> "{kmer}" .
+            """.format(kmer=kmer)
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:
         # The hash is used to ensure blank nodes are unique before assignment

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -553,10 +553,8 @@ class DgraphBulk(Graph):
         pass
 
     def preload(self, k: int = 11):
-        for kmer in possible_kmers(k):
-            self.nquads += """
-            _:{kmer} <km> "{kmer}" .
-            """.format(kmer=kmer)
+        self.nquads = ' '.join('_:{kmer} <km> "{kmer}" .'.format(kmer=kmer)
+                               for kmer in possible_kmers(k))
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:
         # The hash is used to ensure blank nodes are unique before assignment

--- a/prairiedog/dgraph.py
+++ b/prairiedog/dgraph.py
@@ -553,7 +553,7 @@ class DgraphBulk(Graph):
         pass
 
     def preload(self, k: int = 11):
-        self.nquads = ' '.join('_:{kmer} <km> "{kmer}" .'.format(kmer=kmer)
+        self.nquads = '\n'.join('_:{kmer} <km> "{kmer}" .'.format(kmer=kmer)
                                for kmer in possible_kmers(k))
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -31,7 +31,7 @@ class DgraphBundled(Dgraph):
     def init_dgraph(self):
         log.info("Using global offset {}".format(offset))
         self._p_zero = subprocess.Popen(
-            ['dgraph', 'zero', '-o', str(offset), '--wal', self.wal_dir],
+            ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
             cwd=self.tmp_dir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE
@@ -40,7 +40,7 @@ class DgraphBundled(Dgraph):
         self._p_alpha = subprocess.Popen(
             ['dgraph', 'alpha', '--lru_mb', '2048', '--zero',
              'localhost:{}'.format(port("ZERO", offset)),
-             '-o', str(offset), '--wal', self.wal_dir, '--postings',
+             '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
              self.postings_dir],
             cwd=self.tmp_dir,
             stdout=subprocess.DEVNULL,

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -82,7 +82,7 @@ class DgraphBundled(Dgraph):
             time.sleep(1)
             if self._p_ratel.poll() is not None:
                 proc_error(self._p_ratel, "Dgraph Ratel failed to initialize")
-                self.ratel_port = 8000  # This is default
+                self.ratel_port = port("RATEL")  # This is not via offset
 
         # Log ports
         log.info("Initialized Dgraph instance:")

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -6,6 +6,7 @@ import time
 import pathlib
 
 import pydgraph
+import grpc
 
 from prairiedog import debug_and_not_ci
 from prairiedog.node import DEFAULT_NODE_TYPE
@@ -150,8 +151,13 @@ class DgraphBundled(Dgraph):
         super().__init__(offset)
         offset += 1
         log.info("Set global offset to {}".format(offset))
-        self.set_schema()
         self.log_ports()
+        try:
+            self.set_schema()
+        except grpc.RpcError:
+            # In the case that Dgraph hasn't initialized yet
+            time.sleep(3)
+            self.set_schema()
 
     def __del__(self):
         if self.delete:

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -41,7 +41,7 @@ class DgraphBundled(Dgraph):
             ['dgraph', 'alpha', '--lru_mb', '2048', '--zero',
              'localhost:{}'.format(port("ZERO", offset)),
              '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
-             self.postings_dir],
+             str(self.postings_dir)],
             cwd=self.tmp_dir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -40,7 +40,7 @@ class DgraphBundled(Dgraph):
         log.info("Using global offset {}".format(offset))
         self._p_zero = subprocess.Popen(
             ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
-            cwd=self.tmp_dir,
+            cwd=self.out_dir,
             **pipes
         )
         time.sleep(2)
@@ -49,7 +49,7 @@ class DgraphBundled(Dgraph):
              'localhost:{}'.format(port("ZERO", offset)),
              '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
              str(self.postings_dir)],
-            cwd=self.tmp_dir,
+            cwd=self.out_dir,
             **pipes
         )
         time.sleep(4)
@@ -67,19 +67,19 @@ class DgraphBundled(Dgraph):
     def __init__(self, delete: bool = True, output_folder: str = None):
         self.delete = delete
         if output_folder is None:
-            self.tmp_dir = tempfile.mkdtemp()
+            self.out_dir = tempfile.mkdtemp()
         else:
-            self.tmp_dir = pathlib.Path(output_folder)
-            self.tmp_dir.mkdir(parents=True, exist_ok=True)
-        log.info("Will setup Dgraph from folder {}".format(self.tmp_dir))
+            self.out_dir = pathlib.Path(output_folder)
+            self.out_dir.mkdir(parents=True, exist_ok=True)
+        log.info("Will setup Dgraph from folder {}".format(self.out_dir))
         # Postings is only used by alpha
-        self.postings_dir = pathlib.Path(self.tmp_dir, 'p')
+        self.postings_dir = pathlib.Path(self.out_dir, 'p')
         self.postings_dir.mkdir(parents=True, exist_ok=True)
         # This is the wal dir for zero
-        self.wal_dir = pathlib.Path(self.tmp_dir, 'w')
+        self.wal_dir = pathlib.Path(self.out_dir, 'w')
         self.wal_dir.mkdir(parents=True, exist_ok=True)
         # Need separate wal for alpha
-        self.wal_dir_alpha = pathlib.Path(self.tmp_dir, 'alpha', 'w')
+        self.wal_dir_alpha = pathlib.Path(self.out_dir, 'alpha', 'w')
         self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
         # Processes
         self._p_zero = None
@@ -97,5 +97,6 @@ class DgraphBundled(Dgraph):
         time.sleep(2)
         self.shutdown_dgraph()
         if self.delete:
-            shutil.rmtree(self.tmp_dir)
+            log.warning("Wiping {} ...".format(self.out_dir))
+            shutil.rmtree(self.out_dir)
         super().__del__()

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -43,7 +43,7 @@ class DgraphBundled(Dgraph):
             self.subprocess_log_file_alpha = pathlib.Path(
                 self.out_dir, 'dgraph_alpha.log')
             log.info(
-                "Debug mode not set:\nAlpha logs: {}\n Zero logs: {}".format(
+                "Debug mode not set:\nAlpha logs: {}\nZero logs: {}".format(
                     self.subprocess_log_file_zero,
                     self.subprocess_log_file_alpha
                 ))

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -38,7 +38,7 @@ class DgraphBundled(Dgraph):
         self._p_alpha = subprocess.Popen(
             ['dgraph', 'alpha', '--lru_mb', '2048', '--zero',
              'localhost:{}'.format(port("ZERO", offset)),
-             '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
+             '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
             stdout=subprocess.DEVNULL,
@@ -70,8 +70,8 @@ class DgraphBundled(Dgraph):
         self.wal_dir = pathlib.Path(self.tmp_dir, 'w')
         self.wal_dir.mkdir(parents=True, exist_ok=True)
         # Need separate wal for alpha
-        self.wal_dir_alpha = pathlib.Path(self.tmp_dir, 'alpha', 'w')
-        self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
+        # self.wal_dir_alpha = pathlib.Path(self.tmp_dir, 'alpha', 'w')
+        # self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
         # Processes
         self._p_zero = None
         self._p_alpha = None

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -155,9 +155,12 @@ class DgraphBundled(Dgraph):
         self.log_ports()
         try:
             self.set_schema()
-        except grpc.RpcError:
+        except grpc.RpcError as rpc_error_call:
+            log.warning("Ran into exception {}, will retry...".format(
+                rpc_error_call
+            ))
             # In the case that Dgraph hasn't initialized yet
-            time.sleep(3)
+            time.sleep(5)
             self.set_schema()
 
     def __del__(self):

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -66,8 +66,10 @@ class DgraphBundled(Dgraph):
             self.tmp_dir = pathlib.Path(output_folder)
             self.tmp_dir.mkdir(parents=True, exist_ok=True)
         log.info("Will setup Dgraph from folder {}".format(self.tmp_dir))
-        self.postings_dir = os.path.join(self.tmp_dir, '/p')
-        self.wal_dir = os.path.join(self.tmp_dir, '/w')
+        self.postings_dir = pathlib.Path(self.tmp_dir, '/p')
+        self.postings_dir.mkdir(parents=True, exist_ok=True)
+        self.wal_dir = pathlib.Path(self.tmp_dir, '/w')
+        self.wal_dir.mkdir(parents=True, exist_ok=True)
         # Processes
         self._p_zero = None
         self._p_alpha = None

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -38,7 +38,7 @@ class DgraphBundled(Dgraph):
         self._p_alpha = subprocess.Popen(
             ['dgraph', 'alpha', '--lru_mb', '2048', '--zero',
              'localhost:{}'.format(port("ZERO", offset)),
-             '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
+             '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
             stdout=subprocess.DEVNULL,
@@ -70,8 +70,8 @@ class DgraphBundled(Dgraph):
         self.wal_dir = pathlib.Path(self.tmp_dir, 'w')
         self.wal_dir.mkdir(parents=True, exist_ok=True)
         # Need separate wal for alpha
-        # self.wal_dir_alpha = pathlib.Path(self.tmp_dir, 'alpha', 'w')
-        # self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
+        self.wal_dir_alpha = pathlib.Path(self.tmp_dir, 'alpha', 'w')
+        self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
         # Processes
         self._p_zero = None
         self._p_alpha = None

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -4,7 +4,6 @@ import shutil
 import logging
 import time
 import pathlib
-import os
 
 import pydgraph
 
@@ -33,7 +32,7 @@ class DgraphBundled(Dgraph):
         self._p_zero = subprocess.Popen(
             ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
             cwd=self.tmp_dir,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
         time.sleep(2)
@@ -43,7 +42,7 @@ class DgraphBundled(Dgraph):
              '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
         time.sleep(4)

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -44,7 +44,7 @@ class DgraphBundled(Dgraph):
                 ))
             self.subprocess_log = open(self.subprocess_log_file, 'a')
             pipes = {'stdout': self.subprocess_log,
-                     'stderr': self.subprocess}
+                     'stderr': self.subprocess_log}
 
         log.info("Using local offset {}".format(self.offset))
 
@@ -183,7 +183,7 @@ class DgraphBundled(Dgraph):
             log.warning("Wiping {} ...".format(self.out_dir))
             shutil.rmtree(self.out_dir)
         if self.subprocess_log is not None:
-            self.subprocess_log_file.close()
+            self.subprocess_log.close()
         super().__del__()
 
 
@@ -195,5 +195,5 @@ class DgraphBundledException(GraphException):
         log.critical("DgraphBundled encountered an exception")
         if g.subprocess_log_file is not None:
             with open(g.subprocess_log_file) as f:
-                log.critical("Dgraph logs:\n{}".format(f.readlines()))
+                log.critical("Dgraph logs:\n{}".format(f.read()))
         super(DgraphBundledException, self).__init__(g)

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -104,7 +104,6 @@ class DgraphBundled(Dgraph):
                 port("ALPHA_HTTP", self.offset)))
 
     def set_schema(self):
-        log.debug("Trying to set schema for Dgraph...")
         self.client.alter(pydgraph.Operation(schema=DgraphBundled.SCHEMA))
         self.client.alter(pydgraph.Operation(schema=KMERS_SCHEMA))
 
@@ -117,7 +116,7 @@ class DgraphBundled(Dgraph):
             self._p_ratel.terminate()
 
     def __init__(self, delete: bool = True, output_folder: str = None,
-                 ratel: bool = False, set_schema=True):
+                 ratel: bool = False):
         # Ratel is the UI
         self.ratel = ratel
         self.delete = delete
@@ -153,15 +152,12 @@ class DgraphBundled(Dgraph):
         offset += 1
         log.info("Set global offset to {}".format(offset))
         self.log_ports()
-        if set_schema:
-            try:
-                self.set_schema()
-            except grpc.RpcError:
-                log.debug(
-                    "Got an RpcError while trying to set schema, retrying...")
-                # In the case that Dgraph hasn't initialized yet
-                time.sleep(3)
-                self.set_schema()
+        try:
+            self.set_schema()
+        except grpc.RpcError:
+            # In the case that Dgraph hasn't initialized yet
+            time.sleep(3)
+            self.set_schema()
 
     def __del__(self):
         if self.delete:

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -105,6 +105,7 @@ class DgraphBundled(Dgraph):
                 port("ALPHA_HTTP", self.offset)))
 
     def set_schema(self):
+        log.info("Setting dgraph schema...")
         self.client.alter(pydgraph.Operation(schema=DgraphBundled.SCHEMA))
         self.client.alter(pydgraph.Operation(schema=KMERS_SCHEMA))
 
@@ -160,7 +161,8 @@ class DgraphBundled(Dgraph):
                 rpc_error_call
             ))
             # In the case that Dgraph hasn't initialized yet
-            time.sleep(5)
+            time.sleep(10)
+            log.warning("Retying to set schema...")
             self.set_schema()
 
     def __del__(self):

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -70,6 +70,15 @@ class DgraphBundled(Dgraph):
         if self._p_alpha.poll() is not None:
             proc_error(self._p_alpha, "Dgraph Alpha failed to initialize")
 
+        if self.ratel:
+            self._p_ratel = subprocess.Popen(
+                ['dgraph-ratel', '-addr', 'localhost:{}'.format(
+                    port("ZERO", offset))]
+            )
+            time.sleep(1)
+            if self._p_ratel.poll() is not None:
+                proc_error(self._p_ratel, "Dgraph Ratel failed to initialize")
+
     def set_schema(self):
         self.client.alter(pydgraph.Operation(schema=DgraphBundled.SCHEMA))
         self.client.alter(pydgraph.Operation(schema=KMERS_SCHEMA))
@@ -79,8 +88,13 @@ class DgraphBundled(Dgraph):
         time.sleep(2)
         self._p_zero.terminate()
         time.sleep(2)
+        if self._p_ratel is not None:
+            self._p_ratel.terminate()
 
-    def __init__(self, delete: bool = True, output_folder: str = None):
+    def __init__(self, delete: bool = True, output_folder: str = None,
+                 ratel: bool = False):
+        # Ratel is the UI
+        self.ratel = ratel
         self.delete = delete
         if output_folder is None:
             self.out_dir = tempfile.mkdtemp()
@@ -100,6 +114,7 @@ class DgraphBundled(Dgraph):
         # Processes
         self._p_zero = None
         self._p_alpha = None
+        self._p_ratel = None
         self.init_dgraph()
         global offset
         super().__init__(offset)

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -7,6 +7,7 @@ import pathlib
 
 import pydgraph
 
+from prairiedog import debug_and_not_ci
 from prairiedog.node import DEFAULT_NODE_TYPE
 from prairiedog.dgraph import Dgraph, port
 
@@ -28,11 +29,18 @@ class DgraphBundled(Dgraph):
     """.format(DEFAULT_NODE_TYPE)
 
     def init_dgraph(self):
+        if debug_and_not_ci():
+            # Will display subprocess outputs
+            pipes = {}
+        else:
+            # Will not display subprocess outputs
+            pipes = {'stdout': subprocess.DEVNULL, 'stderr': subprocess.DEVNULL}
+
         log.info("Using global offset {}".format(offset))
         self._p_zero = subprocess.Popen(
             ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
             cwd=self.tmp_dir,
-            stdout=subprocess.DEVNULL,
+            **pipes
         )
         time.sleep(2)
         self._p_alpha = subprocess.Popen(
@@ -41,7 +49,7 @@ class DgraphBundled(Dgraph):
              '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
-            stdout=subprocess.DEVNULL,
+            **pipes
         )
         time.sleep(4)
 

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -122,7 +122,7 @@ class DgraphBundled(Dgraph):
         if output_folder is None:
             self.out_dir = tempfile.mkdtemp()
         else:
-            self.out_dir = pathlib.Path(output_folder)
+            self.out_dir = pathlib.Path(output_folder).resolve()
             self.out_dir.mkdir(parents=True, exist_ok=True)
         log.info("Will setup Dgraph from folder {}".format(self.out_dir))
         # Postings is only used by alpha

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -50,7 +50,7 @@ class DgraphBundled(Dgraph):
 
         self._p_zero = subprocess.Popen(
             ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
-            cwd=self.out_dir,
+            cwd=str(self.out_dir),
             **pipes
         )
         time.sleep(2)
@@ -63,7 +63,7 @@ class DgraphBundled(Dgraph):
              'localhost:{}'.format(port("ZERO", offset)),
              '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
              str(self.postings_dir)],
-            cwd=self.out_dir,
+            cwd=str(self.out_dir),
             **pipes
         )
         time.sleep(4)

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -98,7 +98,7 @@ class DgraphBundled(Dgraph):
             log.info("Dgraph Alpha HTTP port    : {}".format(
                 port("ALPHA_HTTP", self.offset)))
         if self.ratel_port:
-            log.info("Dgraph Ratel HTTP port : {}".format(self.ratel_port))
+            log.info("Dgraph Ratel HTTP port    : {}".format(self.ratel_port))
             log.info("Note: Ratel should connect to port {}".format(
                 port("ALPHA_HTTP", self.offset)))
 

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -90,11 +90,17 @@ class DgraphBundled(Dgraph):
         # Log ports
         log.info("Initialized Dgraph instance:")
         if self.zero_port:
-            log.info("Dgraph Zero port  : {}".format(self.zero_port))
+            log.info("Dgraph Zero gRPC port     : {}".format(self.zero_port))
+            log.info("Dgraph Zero HTTP port     : {}".format(
+                port("ZERO_HTTP", self.offset)))
         if self.alpha_port:
-            log.info("Dgraph Alpha port : {}".format(self.alpha_port))
+            log.info("Dgraph Alpha gRPC port    : {}".format(self.alpha_port))
+            log.info("Dgraph Alpha HTTP port    : {}".format(
+                port("ALPHA_HTTP", self.offset)))
         if self.ratel_port:
-            log.info("Dgraph Ratel port : {}".format(self.ratel_port))
+            log.info("Dgraph Ratel HTTP port : {}".format(self.ratel_port))
+            log.info("Note: Ratel should connect to port {}".format(
+                port("ALPHA_HTTP", self.offset)))
 
     def set_schema(self):
         self.client.alter(pydgraph.Operation(schema=DgraphBundled.SCHEMA))
@@ -136,9 +142,11 @@ class DgraphBundled(Dgraph):
         self.zero_port = None
         self.alpha_port = None
         self.ratel_port = None
+        self.offset = None
         # Init dgraph
         self.init_dgraph()
         global offset
+        self.offset = offset
         super().__init__(offset)
         offset += 1
         log.info("Set global offset to {}".format(offset))

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -32,8 +32,6 @@ class DgraphBundled(Dgraph):
         self._p_zero = subprocess.Popen(
             ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
             cwd=self.tmp_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
         )
         time.sleep(2)
         self._p_alpha = subprocess.Popen(
@@ -42,8 +40,6 @@ class DgraphBundled(Dgraph):
              '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
         )
         time.sleep(4)
 

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -40,9 +40,11 @@ class DgraphBundled(Dgraph):
     def init_dgraph(self):
         if debug_and_not_ci():
             # Will display subprocess outputs
+            log.info("Debug mode is set - will output Dgraph logs")
             pipes = {}
         else:
             # Will not display subprocess outputs
+            log.info("Debug mode is not set - will not output Dgraph logs")
             pipes = {'stdout': subprocess.DEVNULL,
                      'stderr': subprocess.DEVNULL}
 
@@ -84,6 +86,7 @@ class DgraphBundled(Dgraph):
                 proc_error(self._p_ratel, "Dgraph Ratel failed to initialize")
                 self.ratel_port = port("RATEL")  # This is not via offset
 
+    def log_ports(self):
         # Log ports
         log.info("Initialized Dgraph instance:")
         if self.zero_port:
@@ -140,6 +143,7 @@ class DgraphBundled(Dgraph):
         offset += 1
         log.info("Set global offset to {}".format(offset))
         self.set_schema()
+        self.log_ports()
 
     def __del__(self):
         if self.delete:

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -62,13 +62,13 @@ class DgraphBundled(Dgraph):
             self.tmp_dir.mkdir(parents=True, exist_ok=True)
         log.info("Will setup Dgraph from folder {}".format(self.tmp_dir))
         # Postings is only used by alpha
-        self.postings_dir = pathlib.Path(self.tmp_dir, '/p')
+        self.postings_dir = pathlib.Path(self.tmp_dir, 'p')
         self.postings_dir.mkdir(parents=True, exist_ok=True)
         # This is the wal dir for zero
-        self.wal_dir = pathlib.Path(self.tmp_dir, '/w')
+        self.wal_dir = pathlib.Path(self.tmp_dir, 'w')
         self.wal_dir.mkdir(parents=True, exist_ok=True)
         # Need separate wal for alpha
-        self.wal_dir_alpha = pathlib.Path(self.tmp_dir, '/alpha', '/w')
+        self.wal_dir_alpha = pathlib.Path(self.tmp_dir, 'alpha', 'w')
         self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
         # Processes
         self._p_zero = None

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -34,7 +34,8 @@ class DgraphBundled(Dgraph):
             pipes = {}
         else:
             # Will not display subprocess outputs
-            pipes = {'stdout': subprocess.DEVNULL, 'stderr': subprocess.DEVNULL}
+            pipes = {'stdout': subprocess.DEVNULL,
+                     'stderr': subprocess.DEVNULL}
 
         log.info("Using global offset {}".format(offset))
         self._p_zero = subprocess.Popen(

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -32,6 +32,7 @@ class DgraphBundled(Dgraph):
         self._p_zero = subprocess.Popen(
             ['dgraph', 'zero', '-o', str(offset), '--wal', str(self.wal_dir)],
             cwd=self.tmp_dir,
+            stdout=subprocess.DEVNULL,
         )
         time.sleep(2)
         self._p_alpha = subprocess.Popen(
@@ -40,6 +41,7 @@ class DgraphBundled(Dgraph):
              '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
+            stdout=subprocess.DEVNULL,
         )
         time.sleep(4)
 

--- a/prairiedog/dgraph_bundled.py
+++ b/prairiedog/dgraph_bundled.py
@@ -37,7 +37,7 @@ class DgraphBundled(Dgraph):
         self._p_alpha = subprocess.Popen(
             ['dgraph', 'alpha', '--lru_mb', '2048', '--zero',
              'localhost:{}'.format(port("ZERO", offset)),
-             '-o', str(offset), '--wal', str(self.wal_dir), '--postings',
+             '-o', str(offset), '--wal', str(self.wal_dir_alpha), '--postings',
              str(self.postings_dir)],
             cwd=self.tmp_dir,
         )
@@ -61,10 +61,15 @@ class DgraphBundled(Dgraph):
             self.tmp_dir = pathlib.Path(output_folder)
             self.tmp_dir.mkdir(parents=True, exist_ok=True)
         log.info("Will setup Dgraph from folder {}".format(self.tmp_dir))
+        # Postings is only used by alpha
         self.postings_dir = pathlib.Path(self.tmp_dir, '/p')
         self.postings_dir.mkdir(parents=True, exist_ok=True)
+        # This is the wal dir for zero
         self.wal_dir = pathlib.Path(self.tmp_dir, '/w')
         self.wal_dir.mkdir(parents=True, exist_ok=True)
+        # Need separate wal for alpha
+        self.wal_dir_alpha = pathlib.Path(self.tmp_dir, '/alpha', '/w')
+        self.wal_dir_alpha.mkdir(parents=True, exist_ok=True)
         # Processes
         self._p_zero = None
         self._p_alpha = None

--- a/prairiedog/dgraph_bundled_helper.py
+++ b/prairiedog/dgraph_bundled_helper.py
@@ -1,0 +1,48 @@
+import logging
+import tempfile
+import pathlib
+
+from prairiedog.dgraph_bundled import DgraphBundled
+from dgraph.bulk import run_dgraph_bulk
+
+
+log = logging.getLogger('prairiedog')
+
+
+class DgraphBundledHelper:
+    """For loading arbitrary rdf and testing"""
+    def __init__(self, out_dir: str = None):
+        # We have to create the first DgraphBundled instance in a temporary
+        # directory and copy the postings from Dgraph Bulk over. Otherwise,
+        # the Dgraph subprocesses will fail to start if initialized from the
+        # same directory.
+        self.tmp_output = tempfile.mkdtemp()
+        if out_dir is not None:
+            self.final_output = pathlib.Path(out_dir).resolve()
+        else:
+            self.final_output = pathlib.Path(tempfile.mkdtemp()).resolve()
+        self._g = None
+
+    def load(self, rdf_dir: str, delete_after: bool = True) -> pathlib.Path:
+        log.info("Loading rdf from {} ...".format(rdf_dir))
+        p = pathlib.Path(self.tmp_output, 'dgraph')
+        p_final = pathlib.Path(self.final_output, 'dgraph')
+        p_final_postings = pathlib.Path(p_final, 'p')
+        self._g = DgraphBundled(delete=False, output_folder=p)
+        run_dgraph_bulk(cwd=p, move_to=p_final_postings,
+                        rdfs=rdf_dir, zero_port=self.g.zero_port)
+        # Reinitialize DgraphBundled after moving postings files
+        self._g.shutdown_dgraph()
+        del self._g
+        self._g = DgraphBundled(delete=delete_after,
+                                output_folder=p_final_postings)
+        return p
+
+    @property
+    def g(self) -> DgraphBundled:
+        if self._g is not None:
+            return self._g
+        else:
+            msg = "load() must be called before accessing g"
+            log.critical(msg)
+            raise AttributeError(msg)

--- a/prairiedog/dgraph_bundled_helper.py
+++ b/prairiedog/dgraph_bundled_helper.py
@@ -20,7 +20,7 @@ class DgraphBundledHelper:
         if out_dir is not None:
             self.final_output = pathlib.Path(out_dir).resolve()
         else:
-            self.final_output = pathlib.Path(tempfile.mkdtemp()).resolve()
+            self.final_output = tempfile.mkdtemp()
         self._g = None
 
     def load(self, rdf_dir: str, delete_after: bool = True) -> pathlib.Path:

--- a/prairiedog/dgraph_bundled_helper.py
+++ b/prairiedog/dgraph_bundled_helper.py
@@ -35,7 +35,7 @@ class DgraphBundledHelper:
         self._g.shutdown_dgraph()
         del self._g
         self._g = DgraphBundled(delete=delete_after,
-                                output_folder=p_final_postings)
+                                output_folder=p_final)
         return p
 
     @property

--- a/prairiedog/dgraph_bundled_helper.py
+++ b/prairiedog/dgraph_bundled_helper.py
@@ -20,7 +20,7 @@ class DgraphBundledHelper:
         if out_dir is not None:
             self.final_output = pathlib.Path(out_dir).resolve()
         else:
-            self.final_output = tempfile.mkdtemp()
+            self.final_output = pathlib.Path(tempfile.mkdtemp()).resolve()
         self._g = None
 
     def load(self, rdf_dir: str, delete_after: bool = True) -> pathlib.Path:

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -29,8 +29,7 @@ class GraphException(Error):
 
 def log_proc(p, msg: str):
     log.fatal(msg)
-    out = p.stdout.read()
-    err = p.stderr.read()
+    out, err = p.communicate()
     log.fatal("stdout:\n{}".format(out))
     log.fatal("stderr:\n{}".format(err))
 

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -1,7 +1,6 @@
 import logging
 
 from prairiedog.graph import Graph
-from prairiedog.dgraph_bundled import DgraphBundled, proc_error
 
 log = logging.getLogger("prairiedog")
 
@@ -28,15 +27,4 @@ class GraphException(Error):
             log.error(edge)
 
 
-class DgraphBundledException(GraphException):
-    """
-    For handling our subprocess exceptions.
-    """
-    def __init__(self, g: DgraphBundled):
-        if g._p_zero is not None:
-            proc_error(g._p_zero, "Dgraph Zero error")
-        if g._p_alpha is not None:
-            proc_error(g._p_alpha, "Dgraph Alpha error")
-        if g._p_ratel is not None:
-            proc_error(g._p_ratel, "Dgraph Ratel error")
-        super(DgraphBundledException, self).__init__(g)
+

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -29,8 +29,8 @@ class GraphException(Error):
 
 def log_proc(p, msg: str):
     log.fatal(msg)
-    p.terminate()
-    out, err = p.communicate()
+    out = p.stdout.read()
+    err = p.stderr.read()
     log.fatal("stdout:\n{}".format(out))
     log.fatal("stderr:\n{}".format(err))
 

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -1,6 +1,7 @@
 import logging
 
 from prairiedog.graph import Graph
+from prairiedog.dgraph_bundled import DgraphBundled, proc_error
 
 log = logging.getLogger("prairiedog")
 
@@ -25,3 +26,17 @@ class GraphException(Error):
         log.error("Dumping edges:")
         for edge in g.edges:
             log.error(edge)
+
+
+class DgraphBundledException(GraphException):
+    """
+    For handling our subprocess exceptions.
+    """
+    def __init__(self, g: DgraphBundled):
+        if g._p_zero is not None:
+            proc_error(g._p_zero, "Dgraph Zero error")
+        if g._p_alpha is not None:
+            proc_error(g._p_alpha, "Dgraph Alpha error")
+        if g._p_ratel is not None:
+            proc_error(g._p_ratel, "Dgraph Ratel error")
+        super(DgraphBundledException, self).__init__(g)

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -29,6 +29,7 @@ class GraphException(Error):
 
 def log_proc(p, msg: str):
     log.fatal(msg)
+    p.terminate()
     out, err = p.communicate()
     log.fatal("stdout:\n{}".format(out))
     log.fatal("stderr:\n{}".format(err))

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -25,3 +25,19 @@ class GraphException(Error):
         log.error("Dumping edges:")
         for edge in g.edges:
             log.error(edge)
+
+
+def log_proc(p, msg: str):
+    log.fatal(msg)
+    out, err = p.communicate()
+    log.fatal("stdout:\n{}".format(out))
+    log.fatal("stderr:\n{}".format(err))
+
+
+class SubprocessException(Error):
+    """
+    Mostly for Dgraph subprocesses.
+    """
+    def __init__(self, p, msg: str):
+        log_proc(p, msg)
+        super(SubprocessException, self).__init__(msg)

--- a/prairiedog/errors.py
+++ b/prairiedog/errors.py
@@ -25,6 +25,3 @@ class GraphException(Error):
         log.error("Dumping edges:")
         for edge in g.edges:
             log.error(edge)
-
-
-

--- a/prairiedog/kmers.py
+++ b/prairiedog/kmers.py
@@ -4,7 +4,14 @@ import os
 import itertools
 import typing
 
+from prairiedog import recommended_procs
+
 log = logging.getLogger("prairiedog")
+
+
+GB_PER_PROC_KMERS = 5
+
+recommended_procs_kmers = recommended_procs(GB_PER_PROC_KMERS)
 
 
 def possible_kmers(k: int = 11) -> typing.Generator:

--- a/prairiedog/lemon_graph.py
+++ b/prairiedog/lemon_graph.py
@@ -113,8 +113,8 @@ class LGGraph(prairiedog.graph.Graph):
             return LGGraph._parse_node(n)
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:
-        na = self.txn.node(type='n', value=edge.src)
-        nb = self.txn.node(type='n', value=edge.tgt)
+        na = self.txn.node(value=edge.src)
+        nb = self.txn.node(value=edge.tgt)
 
         # Add the edge
         e = self.txn.edge(src=na, tgt=nb, type=edge.edge_type,

--- a/prairiedog/lemon_graph.py
+++ b/prairiedog/lemon_graph.py
@@ -8,7 +8,7 @@ import LemonGraph
 import prairiedog.graph
 import prairiedog.config
 from prairiedog.edge import Edge
-from prairiedog.node import Node
+from prairiedog.node import Node, DEFAULT_NODE_TYPE
 from prairiedog.errors import GraphException
 
 
@@ -113,8 +113,8 @@ class LGGraph(prairiedog.graph.Graph):
             return LGGraph._parse_node(n)
 
     def add_edge(self, edge: Edge, echo: bool = True) -> typing.Optional[Edge]:
-        na = self.txn.node(value=edge.src)
-        nb = self.txn.node(value=edge.tgt)
+        na = self.txn.node(type=DEFAULT_NODE_TYPE, value=edge.src)
+        nb = self.txn.node(type=DEFAULT_NODE_TYPE, value=edge.tgt)
 
         # Add the edge
         e = self.txn.edge(src=na, tgt=nb, type=edge.edge_type,

--- a/prairiedog/node.py
+++ b/prairiedog/node.py
@@ -1,6 +1,6 @@
 import typing
 
-DEFAULT_NODE_TYPE = 'n'
+DEFAULT_NODE_TYPE = 'km'
 
 
 class Node:

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup(
     description="Graphing bacterial genomes for fun and profit",
     entry_points={
         'console_scripts': [
-            'prairiedog=prairiedog.cli:query',
-            'prairiedog=prairiedog.cli:dgraph',
+            'prairiedog=prairiedog.cli:cli'
         ],
     },
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     entry_points={
         'console_scripts': [
             'prairiedog=prairiedog.cli:query',
+            'prairiedog=prairiedog.cli:dgraph',
         ],
     },
     install_requires=requirements,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,12 +128,19 @@ def g(request):
         return _dg()
 
 
+@pytest.fixture
 def dgraph_build() -> DgraphBundled:
     tmp_output = tempfile.mkdtemp()
     tmp_samples = tempfile.mkdtemp()
     for f in GENOME_FILES_SHORTENED:
         shutil.copy2(f, tmp_samples)
-    run_dgraph_snakemake('--config ')
+    run_dgraph_snakemake(
+        '--config outputs={outputs} --config samples={samples}'.format(
+            outputs=tmp_output, samples=tmp_samples
+        ))
+    p = os.path.join(tmp_output, 'dgraph/')
+    g = DgraphBundled(delete=True, output_folder=p)
+    return g
 
 #########
 # Prebuilt Graphs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import logging
 import itertools
 import subprocess
 import tempfile
+import pathlib
 
 import pytest
 
@@ -158,10 +159,11 @@ class DgraphBundledHelper:
 
     def load(self, rdf_dir: str):
         log.info("Loading rdf from {} ...".format(rdf_dir))
-        for f in rdf_dir:
-            log.info("Will load {} ...".format(f))
-            shutil.copy2(f, self.tmp_samples)
-        p = os.path.join(self.tmp_output, 'dgraph/')
+        for f in os.listdir(rdf_dir):
+            fp = pathlib.Path(rdf_dir, f)
+            log.info("Will load {} ...".format(fp))
+            shutil.copy2(fp, self.tmp_samples)
+        p = pathlib.Path(self.tmp_output, 'dgraph')
         self._g = DgraphBundled(delete=True, output_folder=p)
         cmd = dgraph_bulk_cmd(
             rdfs=self.tmp_samples, zero_port=self.g.zero_port)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import tempfile
 import pytest
 
 from prairiedog import kmers
+from prairiedog.graph import Graph
 from prairiedog.networkx_graph import NetworkXGraph
 from prairiedog.lemon_graph import LGGraph
 from prairiedog.dgraph_bundled import DgraphBundled
@@ -144,8 +145,7 @@ def setup_snakefile(request):
     subprocess.run("snakemake clean", shell=True)
 
 
-@pytest.fixture
-def lg() -> LGGraph:
+def lg_prebuilt() -> LGGraph:
     """
     A pre-made LemonGraph made from:
         - SRR1060582_SHORTENED.fasta,
@@ -155,3 +155,15 @@ def lg() -> LGGraph:
     """
     g = LGGraph('tests/pangenome.lemongraph', delete_on_exit=False)
     return g
+
+
+def dgraph_prebuilt() -> DgraphBundled:
+    pass
+
+
+@pytest.fixture(params='lemongraph')
+def prebuilt_graph(request) -> Graph:
+    if request.param == 'lemongraph':
+        return lg_prebuilt()
+    elif request.param == 'dgraph':
+        return dgraph_prebuilt()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,7 @@ def dgraph_build() -> DgraphBundled:
     for f in GENOME_FILES_SHORTENED:
         shutil.copy2(f, tmp_samples)
     run_dgraph_snakemake(
-        '--config outputs={outputs} --config samples={samples}'.format(
+        '--config outputs_dir={outputs} --config samples_dir={samples}'.format(
             outputs=tmp_output, samples=tmp_samples
         ))
     p = os.path.join(tmp_output, 'dgraph/')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,12 +130,13 @@ def g(request):
 
 @pytest.fixture
 def dgraph_build() -> DgraphBundled:
+    """Build a bundled dgraph instance via snakemake"""
     tmp_output = tempfile.mkdtemp()
     tmp_samples = tempfile.mkdtemp()
     for f in GENOME_FILES_SHORTENED:
         shutil.copy2(f, tmp_samples)
     run_dgraph_snakemake(
-        '--config outputs_dir={outputs} --config samples_dir={samples}'.format(
+        'outputs_dir={outputs} samples_dir={samples}'.format(
             outputs=tmp_output, samples=tmp_samples
         ))
     p = os.path.join(tmp_output, 'dgraph/')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import logging
 import itertools
 import subprocess
 import tempfile
-import pathlib
 
 import pytest
 
@@ -15,7 +14,6 @@ from prairiedog.networkx_graph import NetworkXGraph
 from prairiedog.lemon_graph import LGGraph
 from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.cli import run_dgraph_snakemake
-from dgraph.bulk import dgraph_bulk_cmd
 
 log = logging.getLogger('prairiedog')
 
@@ -147,42 +145,6 @@ def dgraph_build() -> DgraphBundled:
         ))
     p = os.path.join(tmp_output, 'dgraph/')
     g = DgraphBundled(delete=True, output_folder=p)
-    return g
-
-
-class DgraphBundledHelper:
-    """For loading arbitrary rdf and testing"""
-    def __init__(self):
-        self.tmp_output = tempfile.mkdtemp()
-        self.tmp_samples = tempfile.mkdtemp()
-        self._g = None
-
-    def load(self, rdf_dir: str):
-        log.info("Loading rdf from {} ...".format(rdf_dir))
-        for f in os.listdir(rdf_dir):
-            fp = pathlib.Path(rdf_dir, f)
-            log.info("Will load {} ...".format(fp))
-            shutil.copy2(fp, self.tmp_samples)
-        p = pathlib.Path(self.tmp_output, 'dgraph')
-        self._g = DgraphBundled(delete=True, output_folder=p)
-        cmd = dgraph_bulk_cmd(
-            rdfs=self.tmp_samples, zero_port=self.g.zero_port)
-        log.info("Running command {}".format(cmd))
-        subprocess.run(cmd, shell=True)
-
-    @property
-    def g(self) -> DgraphBundled:
-        if self._g is not None:
-            return self._g
-        else:
-            msg = "load() must be called before accessing g"
-            log.critical(msg)
-            raise AttributeError(msg)
-
-
-@pytest.fixture
-def dgraph_bundled_helper() -> DgraphBundledHelper:
-    g = DgraphBundledHelper()
     return g
 
 #########

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ class DgraphBundledHelper:
         cmd = dgraph_bulk_cmd(
             rdfs=self.tmp_samples, zero_port=self.g.zero_port)
         log.info("Running command {}".format(cmd))
-        subprocess.run(cmd)
+        subprocess.run(cmd, shell=True)
 
     @property
     def g(self) -> DgraphBundled:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,12 +157,15 @@ class DgraphBundledHelper:
         self._g = None
 
     def load(self, rdf_dir: str):
+        log.info("Loading rdf from {} ...".format(rdf_dir))
         for f in rdf_dir:
+            log.info("Will load {} ...".format(f))
             shutil.copy2(f, self.tmp_samples)
         p = os.path.join(self.tmp_output, 'dgraph/')
         self._g = DgraphBundled(delete=True, output_folder=p)
         cmd = dgraph_bulk_cmd(
             rdfs=self.tmp_samples, zero_port=self.g.zero_port)
+        log.info("Running command {}".format(cmd))
         subprocess.run(cmd)
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def dgraph_prebuilt() -> DgraphBundled:
     pass
 
 
-@pytest.fixture(params='lemongraph')
+@pytest.fixture(params=['lemongraph'])
 def prebuilt_graph(request) -> Graph:
     if request.param == 'lemongraph':
         return lg_prebuilt()

--- a/tests/test_connected.py
+++ b/tests/test_connected.py
@@ -1,76 +1,12 @@
 import pytest
 import logging
 
-from prairiedog.lemon_graph import LGGraph
 from prairiedog.graph import Graph
 from prairiedog.node import Node, concat_values
 from prairiedog.edge import Edge
 from prairiedog.errors import GraphException
 
 log = logging.getLogger("prairiedog")
-
-
-#####
-# Tests against a pre-created LemonGraph database
-#####
-
-
-def test_lemongraph_connected(lg: LGGraph):
-    connected, starting_edges = lg.connected('CCGGAAGAAAA', 'CGGAAGAAAAA')
-    if not connected:
-        raise GraphException(lg)
-    else:
-        assert True
-    assert len(starting_edges) == 1
-    log.debug("Found starting_edges as {}".format(starting_edges[0]))
-
-
-def test_lemongraph_connected_path(lg: LGGraph):
-    paths, _ = lg.path('CCGGAAGAAAA', 'CGGAAGAAAAA')
-    assert len(paths) == 1
-
-    path = paths[0]
-    assert path[0].value == 'CCGGAAGAAAA'
-    assert path[1].value == 'CGGAAGAAAAA'
-
-    kmer = concat_values(path)
-    assert kmer == 'CCGGAAGAAAAA'
-
-
-def test_lemongraph_connected_distant(lg: LGGraph):
-    connected, starting_edges = lg.connected('ATACGACGCCA', 'CGTCCGGACGT')
-    if not connected:
-        raise GraphException(lg)
-    else:
-        assert True
-    assert len(starting_edges) == 1
-    log.debug("Found starting_edges as {}".format(starting_edges[0]))
-
-def test_lemongraph_connected_distant_path(lg: LGGraph):
-    paths, _ = lg.path('ATACGACGCCA', 'CGTCCGGACGT')
-    assert len(paths) == 1
-
-    path = paths[0]
-    assert path[0].value == 'ATACGACGCCA'
-    assert path[-1].value == 'CGTCCGGACGT'
-
-    kmer = concat_values(path)
-    assert kmer == 'ATACGACGCCAGCGAACGTCCGGACGT'
-
-
-def test_lemongraph_not_connected(lg: LGGraph):
-    connected, starting_edges = lg.connected('GCTGGATACGT', 'CGTCCGGACGT')
-    if connected:
-        raise GraphException(lg)
-    else:
-        assert True
-    assert len(starting_edges) == 0
-
-
-def test_lemongraph_not_connected_path(lg: LGGraph):
-    paths, _ = lg.path('GCTGGATACGT', 'CGTCCGGACGT')
-    assert len(paths) == 0
-
 
 #####
 # Tests against a fresh database

--- a/tests/test_dgraph.py
+++ b/tests/test_dgraph.py
@@ -27,7 +27,7 @@ def test_dgraph_conftest(dg: Dgraph):
 
 
 def test_dgraph_exists_node(dg: Dgraph):
-    na = Node(node_type='n', value='a')
+    na = Node(value='a')
     exists, _ = dg.exists_node(na)
     assert not exists
     dg.upsert_node(na, echo=False)

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -10,7 +10,7 @@ import pytest
 
 from prairiedog.node import Node
 from prairiedog.dgraph_bundled import DgraphBundled
-from prairiedog.errors import GraphException
+from prairiedog.errors import DgraphBundledException
 from dgraph.bulk import run_dgraph_bulk
 
 
@@ -75,7 +75,7 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper: DgraphBundledHelper):
         log.critical("Couldn't find one of the expected nodes")
         files = glob.glob('{}/**'.format(dg.g.out_dir), recursive=True)
         log.critical("Files is out_dir are:\n{}".format(files))
-        raise GraphException(dg.g)
+        raise DgraphBundledException(dg.g)
 
 
 # TODO: get this to run on CircleCI without being killed

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -11,7 +11,7 @@ import pytest
 from prairiedog.node import Node
 from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.errors import GraphException
-from dgraph.bulk import dgraph_bulk_cmd
+from dgraph.bulk import run_dgraph_bulk
 
 
 log = logging.getLogger('prairiedog')
@@ -32,10 +32,8 @@ class DgraphBundledHelper:
             shutil.copy2(fp, self.tmp_samples)
         p = pathlib.Path(self.tmp_output, 'dgraph')
         self._g = DgraphBundled(delete=delete_after, output_folder=p)
-        cmd = dgraph_bulk_cmd(
-            rdfs=self.tmp_samples, zero_port=self.g.zero_port)
-        log.info("Running command {}".format(cmd))
-        subprocess.run(cmd, shell=True)
+        run_dgraph_bulk(cwd=p, rdfs=self.tmp_samples,
+                        zero_port=self.g.zero_port)
         return p
 
     @property

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -1,62 +1,15 @@
 import tempfile
 import pathlib
 import logging
-import time
-import os
-import shutil
 import glob
 
 import pytest
 
 from prairiedog.node import Node
-from prairiedog.dgraph_bundled import DgraphBundled
-from dgraph.bulk import run_dgraph_bulk
+from prairiedog.dgraph_bundled_helper import DgraphBundledHelper
 
 
 log = logging.getLogger('prairiedog')
-
-
-class DgraphBundledHelper:
-    """For loading arbitrary rdf and testing"""
-    def __init__(self):
-        self.tmp_output = tempfile.mkdtemp()
-        self.tmp_output_b = tempfile.mkdtemp()
-        self.tmp_samples = tempfile.mkdtemp()
-        self._g = None
-
-    def load(self, rdf_dir: str, delete_after: bool = True) -> pathlib.Path:
-        log.info("Loading rdf from {} ...".format(rdf_dir))
-        for f in os.listdir(rdf_dir):
-            fp = pathlib.Path(rdf_dir, f)
-            log.info("Will load {} ...".format(fp))
-            shutil.copy2(fp, self.tmp_samples)
-        p = pathlib.Path(self.tmp_output, 'dgraph')
-        p_b = pathlib.Path(self.tmp_output_b, 'dgraph')
-        p_b_postings = pathlib.Path(p_b, 'p')
-        self._g = DgraphBundled(delete=False, output_folder=p)
-        run_dgraph_bulk(cwd=p, move_to=p_b_postings,
-                        rdfs=self.tmp_samples, zero_port=self.g.zero_port)
-        # Reinitialize DgraphBundled after moving postings files
-        self._g.shutdown_dgraph()
-        # Write out helper text to logs
-        if self._g.subprocess_log_file_zero is not None:
-            with open(self._g.subprocess_log_file_zero, 'a') as f:
-                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***\n""")
-        if self._g.subprocess_log_file_alpha is not None:
-            with open(self._g.subprocess_log_file_alpha, 'a') as f:
-                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***\n""")
-        del self._g
-        self._g = DgraphBundled(delete=delete_after, output_folder=p_b)
-        return p
-
-    @property
-    def g(self) -> DgraphBundled:
-        if self._g is not None:
-            return self._g
-        else:
-            msg = "load() must be called before accessing g"
-            log.critical(msg)
-            raise AttributeError(msg)
 
 
 @pytest.fixture

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -1,11 +1,21 @@
+import tempfile
+import pathlib
+
 from prairiedog.node import Node
 from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.errors import GraphException
 
 
-# def test_dgraph_bulk_basics(dgraph_bundled_helper):
-#     dg = dgraph_bundled_helper
-#     pass
+def test_dgraph_bulk_basics(dgraph_bundled_helper):
+    dg = dgraph_bundled_helper
+    tmp_dir = tempfile.mkdtemp()
+    r1 = pathlib.Path(tmp_dir, 'r1.rdf')
+    with open(r1, 'a') as f:
+        f.write('_:a <km> "ATCG" . ')
+        f.write('_:b <km> "ATGC" . ')
+    dg.load(tmp_dir)
+    assert dg.g.exists_node(Node(value="ATCG"))
+    assert dg.g.exists_node(Node(value="ATGC"))
 
 # TODO: get this to run on CircleCI without being killed
 # def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -31,9 +31,11 @@ class DgraphBundledHelper:
             log.info("Will load {} ...".format(fp))
             shutil.copy2(fp, self.tmp_samples)
         p = pathlib.Path(self.tmp_output, 'dgraph')
-        self._g = DgraphBundled(delete=delete_after, output_folder=p)
+        self._g = DgraphBundled(delete=False, output_folder=p)
         run_dgraph_bulk(cwd=p, move_to=self.g.postings_dir,
                         rdfs=self.tmp_samples, zero_port=self.g.zero_port)
+        # Reinitialize DgraphBundled after moving postings files
+        self._g = DgraphBundled(delete=delete_after, output_folder=p)
         return p
 
     @property

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -5,7 +5,8 @@ import glob
 
 import pytest
 
-from prairiedog.node import Node
+from prairiedog.node import Node, DEFAULT_NODE_TYPE, concat_values
+from prairiedog.dgraph import DEFAULT_EDGE_PREDICATE
 from prairiedog.dgraph_bundled_helper import DgraphBundledHelper
 
 
@@ -23,8 +24,8 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper: DgraphBundledHelper):
     tmp_dir = tempfile.mkdtemp()
     r1 = pathlib.Path(tmp_dir, 'r1.rdf')
     with open(r1, 'a') as f:
-        f.write('_:a <km> "ATCG" . \n')
-        f.write('_:b <km> "ATGC" . \n')
+        f.write('_:a <{n}> "ATCG" . \n_:b <{n}> "ATGC" . \n'.format(
+            n=DEFAULT_NODE_TYPE))
     try:
         dg.load(tmp_dir)
         exists, _ = dg.g.exists_node(Node(value="ATCG"))
@@ -33,6 +34,43 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper: DgraphBundledHelper):
         exists, _ = dg.g.exists_node(Node(value="ATGC"))
         assert exists
         log.info("ATGC exists")
+    except Exception as e:
+        log.critical("Couldn't find one of the expected nodes")
+        files = glob.glob('{}/**'.format(dg.g.out_dir), recursive=True)
+        log.critical("Files is out_dir are:\n{}".format(files))
+        raise e
+
+
+def test_dgraph_bulk_basics_path(dgraph_bundled_helper: DgraphBundledHelper):
+    dg = dgraph_bundled_helper
+    tmp_dir = tempfile.mkdtemp()
+    r1 = pathlib.Path(tmp_dir, 'r1.rdf')
+    with open(r1, 'a') as f:
+        f.write('_:a <{n}> "ATCG" . \n_:b <{n}> "TCGG" . \n'.format(
+            n=DEFAULT_NODE_TYPE))
+        f.write('_:a <{e}> _:e . \n_:e <{e}> _:b . \n'.format(
+            e=DEFAULT_EDGE_PREDICATE))
+        f.write('_:e <type> "contig1" . \n')
+        f.write('_:e <value> "0" . \n')
+    try:
+        dg.load(tmp_dir)
+
+        connected, starting_edges = dg.g.connected('ATCG', 'TCGG')
+        assert connected
+        log.info("Connectivity check passed")
+        assert len(starting_edges) == 1
+        log.info("Length of starting edges check passed")
+
+        paths, _ = dg.g.path('ATCG', 'TCGG')
+        assert len(paths) == 1
+        log.info("Length of paths check passed")
+        path = paths[0]
+        assert path[0].value == 'ATCG'
+        assert path[1].value == 'TCGG'
+        log.info("Path value checks passed")
+        joined = concat_values(path)
+        assert joined == 'ATCGG'
+        log.info("Joined path check passed")
     except Exception as e:
         log.critical("Couldn't find one of the expected nodes")
         files = glob.glob('{}/**'.format(dg.g.out_dir), recursive=True)

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -32,8 +32,8 @@ class DgraphBundledHelper:
             shutil.copy2(fp, self.tmp_samples)
         p = pathlib.Path(self.tmp_output, 'dgraph')
         self._g = DgraphBundled(delete=delete_after, output_folder=p)
-        run_dgraph_bulk(cwd=p, rdfs=self.tmp_samples,
-                        zero_port=self.g.zero_port)
+        run_dgraph_bulk(cwd=p, move_to=self.g.postings_dir,
+                        rdfs=self.tmp_samples, zero_port=self.g.zero_port)
         return p
 
     @property

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -37,7 +37,8 @@ class DgraphBundledHelper:
         # Reinitialize DgraphBundled after moving postings files
         self._g.shutdown_dgraph()
         del self._g
-        self._g = DgraphBundled(delete=delete_after, output_folder=p)
+        self._g = DgraphBundled(
+            delete=delete_after, output_folder=p, set_schema=False)
         return p
 
     @property

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -35,6 +35,13 @@ class DgraphBundledHelper:
                         rdfs=self.tmp_samples, zero_port=self.g.zero_port)
         # Reinitialize DgraphBundled after moving postings files
         self._g.shutdown_dgraph()
+        # Write out helper text to logs
+        if self._g.subprocess_log_file_zero is not None:
+            with open(self._g.subprocess_log_file_zero, 'a') as f:
+                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***""")
+        if self._g.subprocess_log_file_alpha is not None:
+            with open(self._g.subprocess_log_file_alpha, 'a') as f:
+                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***""")
         del self._g
         self._g = DgraphBundled(delete=delete_after, output_folder=p)
         return p

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -1,7 +1,7 @@
 import tempfile
 import pathlib
 import logging
-import subprocess
+import time
 import os
 import shutil
 import glob
@@ -35,6 +35,8 @@ class DgraphBundledHelper:
         run_dgraph_bulk(cwd=p, move_to=self.g.postings_dir,
                         rdfs=self.tmp_samples, zero_port=self.g.zero_port)
         # Reinitialize DgraphBundled after moving postings files
+        self._g.shutdown_dgraph()
+        del self._g
         self._g = DgraphBundled(delete=delete_after, output_folder=p)
         return p
 

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -1,16 +1,60 @@
 import tempfile
 import pathlib
 import logging
+import subprocess
+import os
+import shutil
+import glob
+
+import pytest
 
 from prairiedog.node import Node
 from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.errors import GraphException
+from dgraph.bulk import dgraph_bulk_cmd
 
 
 log = logging.getLogger('prairiedog')
 
 
-def test_dgraph_bulk_basics(dgraph_bundled_helper):
+class DgraphBundledHelper:
+    """For loading arbitrary rdf and testing"""
+    def __init__(self):
+        self.tmp_output = tempfile.mkdtemp()
+        self.tmp_samples = tempfile.mkdtemp()
+        self._g = None
+
+    def load(self, rdf_dir: str, delete_after: bool = True) -> pathlib.Path:
+        log.info("Loading rdf from {} ...".format(rdf_dir))
+        for f in os.listdir(rdf_dir):
+            fp = pathlib.Path(rdf_dir, f)
+            log.info("Will load {} ...".format(fp))
+            shutil.copy2(fp, self.tmp_samples)
+        p = pathlib.Path(self.tmp_output, 'dgraph')
+        self._g = DgraphBundled(delete=delete_after, output_folder=p)
+        cmd = dgraph_bulk_cmd(
+            rdfs=self.tmp_samples, zero_port=self.g.zero_port)
+        log.info("Running command {}".format(cmd))
+        subprocess.run(cmd, shell=True)
+        return p
+
+    @property
+    def g(self) -> DgraphBundled:
+        if self._g is not None:
+            return self._g
+        else:
+            msg = "load() must be called before accessing g"
+            log.critical(msg)
+            raise AttributeError(msg)
+
+
+@pytest.fixture
+def dgraph_bundled_helper() -> DgraphBundledHelper:
+    g = DgraphBundledHelper()
+    return g
+
+
+def test_dgraph_bulk_basics(dgraph_bundled_helper: DgraphBundledHelper):
     dg = dgraph_bundled_helper
     tmp_dir = tempfile.mkdtemp()
     r1 = pathlib.Path(tmp_dir, 'r1.rdf')
@@ -18,12 +62,19 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper):
         f.write('_:a <km> "ATCG" . \n')
         f.write('_:b <km> "ATGC" . \n')
     dg.load(tmp_dir)
-    exists, _ = dg.g.exists_node(Node(value="ATCG"))
-    assert exists
-    log.info("ATCG exists")
-    exists, _ = dg.g.exists_node(Node(value="ATGC"))
-    assert exists
-    log.info("ATGC exists")
+    try:
+        exists, _ = dg.g.exists_node(Node(value="ATCG"))
+        assert exists
+        log.info("ATCG exists")
+        exists, _ = dg.g.exists_node(Node(value="ATGC"))
+        assert exists
+        log.info("ATGC exists")
+    except Exception as e:
+        log.critical("Couldn't find one of the expected nodes")
+        files = glob.glob('{}/**'.format(dg.g.out_dir), recursive=True)
+        log.critical("Files is out_dir are:\n{}".format(files))
+        raise GraphException(dg.g)
+
 
 # TODO: get this to run on CircleCI without being killed
 # def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -10,7 +10,6 @@ import pytest
 
 from prairiedog.node import Node
 from prairiedog.dgraph_bundled import DgraphBundled
-from prairiedog.errors import DgraphBundledException
 from dgraph.bulk import run_dgraph_bulk
 
 
@@ -75,7 +74,7 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper: DgraphBundledHelper):
         log.critical("Couldn't find one of the expected nodes")
         files = glob.glob('{}/**'.format(dg.g.out_dir), recursive=True)
         log.critical("Files is out_dir are:\n{}".format(files))
-        raise DgraphBundledException(dg.g)
+        raise e
 
 
 # TODO: get this to run on CircleCI without being killed

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -1,0 +1,13 @@
+from prairiedog.node import Node
+from prairiedog.dgraph_bundled import DgraphBundled
+from prairiedog.errors import GraphException
+
+
+def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):
+    na = Node(value='GTGCAAGTGAG')
+    nb = Node(value='AAATTCCGGAC')
+    try:
+        assert dgraph_build.exists_node(na)
+        assert dgraph_build.exists_node(nb)
+    except:
+        raise GraphException(dgraph_build)

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -37,8 +37,7 @@ class DgraphBundledHelper:
         # Reinitialize DgraphBundled after moving postings files
         self._g.shutdown_dgraph()
         del self._g
-        self._g = DgraphBundled(
-            delete=delete_after, output_folder=p, set_schema=False)
+        self._g = DgraphBundled(delete=delete_after, output_folder=p)
         return p
 
     @property

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -3,6 +3,11 @@ from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.errors import GraphException
 
 
+# def test_dgraph_bulk_basics(dgraph_bundled_helper):
+#     dg = dgraph_bundled_helper
+#     pass
+
+# TODO: get this to run on CircleCI without being killed
 # def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):
 #     na = Node(value='GTGCAAGTGAG')
 #     nb = Node(value='AAATTCCGGAC')

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -3,11 +3,11 @@ from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.errors import GraphException
 
 
-def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):
-    na = Node(value='GTGCAAGTGAG')
-    nb = Node(value='AAATTCCGGAC')
-    try:
-        assert dgraph_build.exists_node(na)
-        assert dgraph_build.exists_node(nb)
-    except:
-        raise GraphException(dgraph_build)
+# def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):
+#     na = Node(value='GTGCAAGTGAG')
+#     nb = Node(value='AAATTCCGGAC')
+#     try:
+#         assert dgraph_build.exists_node(na)
+#         assert dgraph_build.exists_node(nb)
+#     except:
+#         raise GraphException(dgraph_build)

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -20,6 +20,7 @@ class DgraphBundledHelper:
     """For loading arbitrary rdf and testing"""
     def __init__(self):
         self.tmp_output = tempfile.mkdtemp()
+        self.tmp_output_b = tempfile.mkdtemp()
         self.tmp_samples = tempfile.mkdtemp()
         self._g = None
 
@@ -30,20 +31,22 @@ class DgraphBundledHelper:
             log.info("Will load {} ...".format(fp))
             shutil.copy2(fp, self.tmp_samples)
         p = pathlib.Path(self.tmp_output, 'dgraph')
+        p_b = pathlib.Path(self.tmp_output_b, 'dgraph')
+        p_b_postings = pathlib.Path(p_b, 'p')
         self._g = DgraphBundled(delete=False, output_folder=p)
-        run_dgraph_bulk(cwd=p, move_to=self.g.postings_dir,
+        run_dgraph_bulk(cwd=p, move_to=p_b_postings,
                         rdfs=self.tmp_samples, zero_port=self.g.zero_port)
         # Reinitialize DgraphBundled after moving postings files
         self._g.shutdown_dgraph()
         # Write out helper text to logs
         if self._g.subprocess_log_file_zero is not None:
             with open(self._g.subprocess_log_file_zero, 'a') as f:
-                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***""")
+                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***\n""")
         if self._g.subprocess_log_file_alpha is not None:
             with open(self._g.subprocess_log_file_alpha, 'a') as f:
-                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***""")
+                f.write("""***\n\nRestarted DgraphBundled Logs\n\n***\n""")
         del self._g
-        self._g = DgraphBundled(delete=delete_after, output_folder=p)
+        self._g = DgraphBundled(delete=delete_after, output_folder=p_b)
         return p
 
     @property

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -18,9 +18,11 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper):
         f.write('_:a <km> "ATCG" . \n')
         f.write('_:b <km> "ATGC" . \n')
     dg.load(tmp_dir)
-    assert dg.g.exists_node(Node(value="ATCG"))
+    exists, _ = dg.g.exists_node(Node(value="ATCG"))
+    assert exists
     log.info("ATCG exists")
-    assert dg.g.exists_node(Node(value="ATGC"))
+    exists, _ = dg.g.exists_node(Node(value="ATGC"))
+    assert exists
     log.info("ATGC exists")
 
 # TODO: get this to run on CircleCI without being killed

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -63,8 +63,8 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper: DgraphBundledHelper):
     with open(r1, 'a') as f:
         f.write('_:a <km> "ATCG" . \n')
         f.write('_:b <km> "ATGC" . \n')
-    dg.load(tmp_dir)
     try:
+        dg.load(tmp_dir)
         exists, _ = dg.g.exists_node(Node(value="ATCG"))
         assert exists
         log.info("ATCG exists")

--- a/tests/test_dgraph_bulk.py
+++ b/tests/test_dgraph_bulk.py
@@ -1,9 +1,13 @@
 import tempfile
 import pathlib
+import logging
 
 from prairiedog.node import Node
 from prairiedog.dgraph_bundled import DgraphBundled
 from prairiedog.errors import GraphException
+
+
+log = logging.getLogger('prairiedog')
 
 
 def test_dgraph_bulk_basics(dgraph_bundled_helper):
@@ -11,11 +15,13 @@ def test_dgraph_bulk_basics(dgraph_bundled_helper):
     tmp_dir = tempfile.mkdtemp()
     r1 = pathlib.Path(tmp_dir, 'r1.rdf')
     with open(r1, 'a') as f:
-        f.write('_:a <km> "ATCG" . ')
-        f.write('_:b <km> "ATGC" . ')
+        f.write('_:a <km> "ATCG" . \n')
+        f.write('_:b <km> "ATGC" . \n')
     dg.load(tmp_dir)
     assert dg.g.exists_node(Node(value="ATCG"))
+    log.info("ATCG exists")
     assert dg.g.exists_node(Node(value="ATGC"))
+    log.info("ATGC exists")
 
 # TODO: get this to run on CircleCI without being killed
 # def test_dgraph_bulk_snakemake(dgraph_build: DgraphBundled):

--- a/tests/test_prebuilt.py
+++ b/tests/test_prebuilt.py
@@ -1,0 +1,75 @@
+import logging
+
+from prairiedog.graph import Graph
+from prairiedog.errors import GraphException
+from prairiedog.node import concat_values
+
+log = logging.getLogger("prairiedog")
+
+#####
+# Tests against a pre-built database
+# Made from:
+# - SRR1060582_SHORTENED.fasta,
+# - SRR1106609_SHORTENED.fasta
+# - GCA_900015695.1_ED647_contigs_genomic_SHORTENED.fasta
+#####
+
+
+def test_lemongraph_connected(prebuilt_graph: Graph):
+    connected, starting_edges = prebuilt_graph.connected(
+        'CCGGAAGAAAA', 'CGGAAGAAAAA')
+    if not connected:
+        raise GraphException(prebuilt_graph)
+    else:
+        assert True
+    assert len(starting_edges) == 1
+    log.debug("Found starting_edges as {}".format(starting_edges[0]))
+
+
+def test_lemongraph_connected_path(prebuilt_graph: Graph):
+    paths, _ = prebuilt_graph.path('CCGGAAGAAAA', 'CGGAAGAAAAA')
+    assert len(paths) == 1
+
+    path = paths[0]
+    assert path[0].value == 'CCGGAAGAAAA'
+    assert path[1].value == 'CGGAAGAAAAA'
+
+    kmer = concat_values(path)
+    assert kmer == 'CCGGAAGAAAAA'
+
+
+def test_lemongraph_connected_distant(prebuilt_graph: Graph):
+    connected, starting_edges = prebuilt_graph.connected('ATACGACGCCA', 'CGTCCGGACGT')
+    if not connected:
+        raise GraphException(prebuilt_graph)
+    else:
+        assert True
+    assert len(starting_edges) == 1
+    log.debug("Found starting_edges as {}".format(starting_edges[0]))
+
+
+def test_lemongraph_connected_distant_path(prebuilt_graph: Graph):
+    paths, _ = prebuilt_graph.path('ATACGACGCCA', 'CGTCCGGACGT')
+    assert len(paths) == 1
+
+    path = paths[0]
+    assert path[0].value == 'ATACGACGCCA'
+    assert path[-1].value == 'CGTCCGGACGT'
+
+    kmer = concat_values(path)
+    assert kmer == 'ATACGACGCCAGCGAACGTCCGGACGT'
+
+
+def test_lemongraph_not_connected(prebuilt_graph: Graph):
+    connected, starting_edges = prebuilt_graph.connected(
+        'GCTGGATACGT', 'CGTCCGGACGT')
+    if connected:
+        raise GraphException(prebuilt_graph)
+    else:
+        assert True
+    assert len(starting_edges) == 0
+
+
+def test_lemongraph_not_connected_path(prebuilt_graph: Graph):
+    paths, _ = prebuilt_graph.path('GCTGGATACGT', 'CGTCCGGACGT')
+    assert len(paths) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py35, py36, py37, pypy36
+envlist = flake8, py36, py37, pypy36
 
 [flake8]
 exclude = tests/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, pypy36, flake8,
+envlist = flake8, py35, py36, py37, pypy36
 
 [flake8]
 exclude = tests/*


### PR DESCRIPTION
Additional Changes:
+ Move lemongraph install into base test image
+ Change Dockerfile entry into prariedog instead of Snakemake
+ Drop support for Py3.5 due to pathlib inconsistencies
+ Support and output directory and sample directory config in Snakefile
+ Add a `dgraph` rule in Snakefile for running `dgraph bulk`
+ Implement a custom run_dgraph_bulk() function
+ Silence Dgraph output logs if in `--debug` not specified, or in CI
+ Add prairiedog Click commands for running `dgraph bulk` and `dgraph ratel`
+ Fix preloading of Kmer .rdf
+ Additional support for DgraphBundled subprocess logs
+ Support outputting Dgraph files to a specific directory
+ Additional exception handling for DgraphBundled